### PR TITLE
Fix contact form 405 error by enabling API routes

### DIFF
--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -8,6 +8,9 @@ export async function POST(request: Request) {
     const body = await request.json();
     const { name, email, company, phone, message } = body;
 
+    console.log('Contact form submission:', { name, email, company, phone });
+    console.log('Resend API Key exists:', !!process.env.RESEND_API_KEY);
+
     // Send email using Resend
     // Note: The 'from' email must be verified in Resend dashboard
     // For now, using onboarding@resend.dev which works for testing

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -148,9 +148,12 @@ export default function ContactPage() {
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setIsSubmitting(true);
-    
+
+    // Store form reference
+    const form = e.currentTarget;
+
     // Get form data
-    const formData = new FormData(e.currentTarget);
+    const formData = new FormData(form);
     const formValues = {
       name: formData.get('name') as string,
       email: formData.get('email') as string,
@@ -158,7 +161,7 @@ export default function ContactPage() {
       phone: formData.get('phone') as string,
       message: formData.get('message') as string,
     };
-    
+
     try {
       // Send to API
       const response = await fetch('/api/contact', {
@@ -169,21 +172,26 @@ export default function ContactPage() {
         body: JSON.stringify(formValues),
       });
 
+      const responseData = await response.json();
+      console.log('API Response:', response.status, responseData);
+
       if (!response.ok) {
-        throw new Error('Failed to send message');
+        throw new Error(responseData.error || 'Failed to send message');
       }
-      
+
       // Track form submission
-      trackContactForm({ 
+      trackContactForm({
         company: formValues.company || undefined,
         industry: undefined
       });
-      
+
       // Show success message
       alert("Thank you for your message! We'll get back to you within 24 hours.");
-      
-      // Reset form
-      e.currentTarget.reset();
+
+      // Reset form safely
+      if (form) {
+        form.reset();
+      }
     } catch (error) {
       console.error('Error submitting form:', error);
       alert("Sorry, there was an error sending your message. Please try again or email us directly at admin@triya.ai");

--- a/next.config.js
+++ b/next.config.js
@@ -1,11 +1,13 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  output: 'export',
+  // Remove 'output: export' to enable API routes on Vercel
+  // output: 'export', // This prevents API routes from working
   images: {
     unoptimized: true,
   },
   basePath: '',
   assetPrefix: '',
+  // Keep trailingSlash for consistency with existing URLs
   trailingSlash: true,
 }
 


### PR DESCRIPTION
## Summary
- Fixed the 405 Method Not Allowed error on the contact form submission
- Enabled API routes by removing static export configuration
- Improved error handling and user feedback

## Problem
The contact form at https://www.triya.ai/contact/ was returning a 405 Method Not Allowed error when users tried to submit the form.

## Root Cause
The Next.js configuration had `output: 'export'` which creates a static site. Static sites cannot run API routes - they require a Node.js server runtime.

## Solution
1. **Removed `output: 'export'` from next.config.js** - This enables API routes on Vercel
2. **Added logging to the API endpoint** - Better debugging capabilities
3. **Improved form error handling** - Better user experience with proper error messages
4. **Fixed form reset issue** - Form now properly resets after successful submission

## Testing
- ✅ Tested locally - form submits successfully
- ✅ API returns 200 status
- ✅ Success message displays correctly
- ✅ Form resets after submission

## Deployment Notes
Once deployed to Vercel, the contact form will work properly as API routes are now enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)