### PR TITLE
Remove Arabic language toggle — make site English-only

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState, useEffect } from "react";
 import { motion } from "framer-motion";
 import { fadeInUp, staggerChildren } from "@/lib/motion-variants";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -19,114 +18,55 @@ import Link from "next/link";
 import { Button } from "@/components/ui/button";
 
 export default function AboutPage() {
-  const [language, setLanguage] = useState<"en" | "ar">("en");
-
-  useEffect(() => {
-    const savedLang = localStorage.getItem("language") as "en" | "ar";
-    if (savedLang) {
-      setLanguage(savedLang);
-      document.documentElement.dir = savedLang === "ar" ? "rtl" : "ltr";
-    }
-  }, []);
-
   const content = {
-    en: {
-      hero: {
-        title: "Building the Future of",
-        titleHighlight: "Intelligent Security",
-        subtitle: "Triya.ai is revolutionizing surveillance with edge AI technology, bringing real-time intelligence to security operations across the GCC region."
-      },
-      mission: {
-        title: "Our Mission",
-        description: "To democratize AI-powered security by making advanced surveillance accessible, affordable, and effective for organizations of all sizes across the Middle East.",
-        stats: [
-          { label: "Founded", value: "2025" },
-          { label: "Team Size", value: "15+" },
-          { label: "Countries (target by end 2025)", value: "2" },
-          { label: "Deployments (target by 2025)", value: "5+" }
-        ]
-      },
-      values: {
-        title: "Our Values",
-        items: [
-          {
-            icon: Shield,
-            title: "Security First",
-            description: "On-premise processing ensures complete data sovereignty and privacy compliance."
-          },
-          {
-            icon: Globe,
-            title: "Regional Focus",
-            description: "Built specifically for GCC markets with Arabic-first capabilities."
-          },
-          {
-            icon: Lightbulb,
-            title: "Innovation",
-            description: "Pushing the boundaries of edge AI to deliver real-time intelligent solutions."
-          },
-          {
-            icon: Users,
-            title: "Customer Success",
-            description: "Dedicated to helping our clients achieve their security objectives."
-          }
-        ]
-      },
-      cta: {
-        title: "Join Us in Transforming Security",
-        description: "Partner with us to bring intelligent surveillance to your organization",
-        button: "Get Started"
-      }
+    hero: {
+      title: "Building the Future of",
+      titleHighlight: "Intelligent Security",
+      subtitle: "Triya.ai is revolutionizing surveillance with edge AI technology, bringing real-time intelligence to security operations across the GCC region."
     },
-    ar: {
-      hero: {
-        title: "بناء مستقبل",
-        titleHighlight: "الأمن الذكي",
-        subtitle: "تُحدث Triya.ai ثورة في المراقبة باستخدام تقنية الذكاء الاصطناعي الطرفي، مما يجلب الذكاء في الوقت الفعلي لعمليات الأمن في جميع أنحاء منطقة دول مجلس التعاون الخليجي."
-      },
-      mission: {
-        title: "مهمتنا",
-        description: "إضفاء الطابع الديمقراطي على الأمن المدعوم بالذكاء الاصطناعي من خلال جعل المراقبة المتقدمة في متناول الجميع وبأسعار معقولة وفعالة للمؤسسات من جميع الأحجام في جميع أنحاء الشرق الأوسط.",
-        stats: [
-          { label: "تأسست", value: "2025" },
-          { label: "حجم الفريق", value: "15+" },
-          { label: "البلدان (الهدف بنهاية 2025)", value: "2" },
-          { label: "عمليات النشر (الهدف بحلول 2025)", value: "5+" }
-        ]
-      },
-      values: {
-        title: "قيمنا",
-        items: [
-          {
-            icon: Shield,
-            title: "الأمن أولاً",
-            description: "تضمن المعالجة المحلية السيادة الكاملة على البيانات والامتثال للخصوصية."
-          },
-          {
-            icon: Globe,
-            title: "التركيز الإقليمي",
-            description: "تم بناؤه خصيصًا لأسواق دول مجلس التعاون الخليجي مع قدرات عربية أولاً."
-          },
-          {
-            icon: Lightbulb,
-            title: "الابتكار",
-            description: "دفع حدود الذكاء الاصطناعي الطرفي لتقديم حلول ذكية في الوقت الفعلي."
-          },
-          {
-            icon: Users,
-            title: "نجاح العملاء",
-            description: "مكرسة لمساعدة عملائنا على تحقيق أهدافهم الأمنية."
-          }
-        ]
-      },
-      cta: {
-        title: "انضم إلينا في تحويل الأمن",
-        description: "شارك معنا لجلب المراقبة الذكية إلى مؤسستك",
-        button: "ابدأ الآن"
-      }
+    mission: {
+      title: "Our Mission",
+      description: "To democratize AI-powered security by making advanced surveillance accessible, affordable, and effective for organizations of all sizes across the Middle East.",
+      stats: [
+        { label: "Founded", value: "2025" },
+        { label: "Team Size", value: "15+" },
+        { label: "Countries (target by end 2025)", value: "2" },
+        { label: "Deployments (target by 2025)", value: "5+" }
+      ]
+    },
+    values: {
+      title: "Our Values",
+      items: [
+        {
+          icon: Shield,
+          title: "Security First",
+          description: "On-premise processing ensures complete data sovereignty and privacy compliance."
+        },
+        {
+          icon: Globe,
+          title: "Regional Focus",
+          description: "Built specifically for GCC markets with Arabic-first capabilities."
+        },
+        {
+          icon: Lightbulb,
+          title: "Innovation",
+          description: "Pushing the boundaries of edge AI to deliver real-time intelligent solutions."
+        },
+        {
+          icon: Users,
+          title: "Customer Success",
+          description: "Dedicated to helping our clients achieve their security objectives."
+        }
+      ]
+    },
+    cta: {
+      title: "Join Us in Transforming Security",
+      description: "Partner with us to bring intelligent surveillance to your organization",
+      button: "Get Started"
     }
   };
 
-  const t = content[language];
+  const t = content;
 
   return (
     <div className="min-h-screen bg-background">

--- a/app/blog/[slug]/blog-article-client.tsx
+++ b/app/blog/[slug]/blog-article-client.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import { useState, useEffect } from 'react';
 import Link from 'next/link';
-import { ArrowLeft, ArrowRight, Calendar, Clock, Tag } from 'lucide-react';
+import { ArrowLeft, Calendar, Clock, Tag } from 'lucide-react';
 import { ShareButton } from '../components/share-button';
 import { ContentRenderer } from '../components/content-renderer';
 import { BlogErrorBoundary } from '../components/error-boundary';
@@ -12,37 +11,17 @@ interface BlogArticleClientProps {
 }
 
 export function BlogArticleClient({ article }: BlogArticleClientProps) {
-  const [language, setLanguage] = useState<"en" | "ar">("en");
-
-  useEffect(() => {
-    const savedLang = localStorage.getItem("language") as "en" | "ar";
-    if (savedLang) {
-      setLanguage(savedLang);
-      document.documentElement.dir = savedLang === "ar" ? "rtl" : "ltr";
-    }
-  }, []);
-
   const content = {
-    en: {
-      backToBlog: "Back to Blog",
-      by: "By",
-      readyToTransform: "Ready to Transform Your Surveillance?",
-      readyDescription: "Experience the power of edge AI surveillance with 85% cost savings. Get a personalized demo for your business today.",
-      requestDemo: "Request Demo",
-      viewFaq: "View FAQ"
-    },
-    ar: {
-      backToBlog: "العودة إلى المدونة",
-      by: "بواسطة",
-      readyToTransform: "هل أنت مستعد لتحويل نظام المراقبة الخاص بك؟",
-      readyDescription: "اختبر قوة المراقبة بالذكاء الاصطناعي الطرفي مع توفير 85% من التكاليف. احصل على عرض توضيحي مخصص لعملك اليوم.",
-      requestDemo: "طلب عرض توضيحي",
-      viewFaq: "عرض الأسئلة الشائعة"
-    }
+    backToBlog: "Back to Blog",
+    by: "By",
+    readyToTransform: "Ready to Transform Your Surveillance?",
+    readyDescription: "Experience the power of edge AI surveillance with 85% cost savings. Get a personalized demo for your business today.",
+    requestDemo: "Request Demo",
+    viewFaq: "View FAQ"
   };
 
-  const t = content[language];
-  const BackArrow = language === "ar" ? ArrowRight : ArrowLeft;
+  const t = content;
+  const BackArrow = ArrowLeft;
 
   return (
     <article className="min-h-screen py-12">
@@ -60,23 +39,23 @@ export function BlogArticleClient({ article }: BlogArticleClientProps) {
         <header className="max-w-4xl mx-auto mb-12">
           <div className="flex items-center gap-2 flex-wrap mb-4">
             <span className="px-3 py-1 bg-primary/10 text-primary text-sm font-medium rounded">
-              {article.category[language]}
+              {article.category.en}
             </span>
           </div>
 
           <h1 className="text-3xl sm:text-4xl lg:text-5xl font-bold mb-4 leading-tight">
-            {article.title[language]}
+            {article.title.en}
           </h1>
 
           <p className="text-xl text-muted-foreground mb-6">
-            {article.excerpt[language]}
+            {article.excerpt.en}
           </p>
 
           <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 pb-6 border-b">
             <div className="flex items-center gap-4 text-sm text-muted-foreground">
               <span className="flex items-center gap-1">
                 <Calendar className="h-4 w-4" />
-                {new Date(article.date).toLocaleDateString(language === 'ar' ? 'ar-SA' : 'en-US', { 
+                {new Date(article.date).toLocaleDateString('en-US', {
                   month: 'long', 
                   day: 'numeric', 
                   year: 'numeric' 
@@ -84,7 +63,7 @@ export function BlogArticleClient({ article }: BlogArticleClientProps) {
               </span>
               <span className="flex items-center gap-1">
                 <Clock className="h-4 w-4" />
-                {article.readTime[language]}
+                {article.readTime.en}
               </span>
               <span>{t.by} {article.author}</span>
             </div>
@@ -97,7 +76,7 @@ export function BlogArticleClient({ article }: BlogArticleClientProps) {
         <div className="max-w-4xl mx-auto">
           <div className="prose prose-lg dark:prose-invert max-w-none">
             <BlogErrorBoundary>
-              <ContentRenderer content={article.content[language]} />
+              <ContentRenderer content={article.content.en} />
             </BlogErrorBoundary>
           </div>
 
@@ -105,7 +84,7 @@ export function BlogArticleClient({ article }: BlogArticleClientProps) {
           <div className="mt-12 pt-6 border-t">
             <div className="flex items-center gap-2 flex-wrap">
               <Tag className="h-4 w-4 text-muted-foreground" />
-              {article.tags[language].map((tag: string) => (
+              {article.tags.en.map((tag: string) => (
                 <Link
                   key={tag}
                   href={`/blog/?tag=${encodeURIComponent(tag)}`}

--- a/app/blog/components/share-button.tsx
+++ b/app/blog/components/share-button.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Share2, Check } from 'lucide-react';
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 
 interface ShareButtonProps {
   article: {
@@ -12,27 +12,13 @@ interface ShareButtonProps {
 
 export function ShareButton({ article }: ShareButtonProps) {
   const [copied, setCopied] = useState(false);
-  const [language, setLanguage] = useState<"en" | "ar">("en");
-
-  useEffect(() => {
-    const savedLang = localStorage.getItem("language") as "en" | "ar";
-    if (savedLang) {
-      setLanguage(savedLang);
-    }
-  }, []);
 
   const translations = {
-    en: {
-      share: "Share",
-      copied: "Copied!"
-    },
-    ar: {
-      share: "مشاركة",
-      copied: "تم النسخ!"
-    }
+    share: "Share",
+    copied: "Copied!"
   };
 
-  const t = translations[language];
+  const t = translations;
 
   const handleShare = async () => {
     if (navigator.share) {

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,48 +1,26 @@
 "use client";
 
-import { useState, useEffect } from 'react';
 import { getAllArticlesMetadata } from './lib/articles-metadata';
 import Link from 'next/link';
 import Image from 'next/image';
-import { ArrowRight, ArrowLeft, Clock, Calendar } from 'lucide-react';
+import { ArrowRight, Clock, Calendar } from 'lucide-react';
 import { Breadcrumbs } from '@/components/shared/breadcrumbs';
 
 export default function BlogPage() {
-  const [language, setLanguage] = useState<"en" | "ar">("en");
   const articles = getAllArticlesMetadata();
 
-  useEffect(() => {
-    // Check for saved language preference
-    const savedLang = localStorage.getItem("language") as "en" | "ar";
-    if (savedLang) {
-      setLanguage(savedLang);
-      document.documentElement.dir = savedLang === "ar" ? "rtl" : "ltr";
-    }
-  }, []);
-
   const content = {
-    en: {
-      title: "Triya Blog",
-      subtitle: "Insights on AI surveillance, edge computing, and security technology for the Middle East market",
-      featured: "Featured",
-      readArticle: "Read Article",
-      ctaTitle: "Stay Updated on AI Surveillance Trends",
-      ctaSubtitle: "Get the latest insights on edge AI, security technology, and surveillance best practices for the Middle East market.",
-      ctaButton: "Subscribe to Updates"
-    },
-    ar: {
-      title: "مدونة تريا",
-      subtitle: "رؤى حول المراقبة بالذكاء الاصطناعي والحوسبة الطرفية وتكنولوجيا الأمن لسوق الشرق الأوسط",
-      featured: "مميز",
-      readArticle: "اقرأ المقال",
-      ctaTitle: "ابق على اطلاع على اتجاهات المراقبة بالذكاء الاصطناعي",
-      ctaSubtitle: "احصل على أحدث الرؤى حول الذكاء الاصطناعي الطرفي وتكنولوجيا الأمن وأفضل ممارسات المراقبة لسوق الشرق الأوسط.",
-      ctaButton: "اشترك في التحديثات"
-    }
+    title: "Triya Blog",
+    subtitle: "Insights on AI surveillance, edge computing, and security technology for the Middle East market",
+    featured: "Featured",
+    readArticle: "Read Article",
+    ctaTitle: "Stay Updated on AI Surveillance Trends",
+    ctaSubtitle: "Get the latest insights on edge AI, security technology, and surveillance best practices for the Middle East market.",
+    ctaButton: "Subscribe to Updates"
   };
 
-  const t = content[language];
-  const ArrowIcon = language === "ar" ? ArrowLeft : ArrowRight;
+  const t = content;
+  const ArrowIcon = ArrowRight;
 
   return (
     <>
@@ -80,20 +58,20 @@ export default function BlogPage() {
                       </span>
                       <span className="flex items-center gap-1">
                         <Clock className="h-4 w-4" />
-                        {articles[0].readTime[language]}
+                        {articles[0].readTime.en}
                       </span>
                     </div>
                     
                     <h2 className="text-2xl md:text-3xl font-bold mb-3 group-hover:text-primary transition-colors">
-                      {articles[0].title[language]}
+                      {articles[0].title.en}
                     </h2>
                     
                     <p className="text-muted-foreground mb-4 line-clamp-3">
-                      {articles[0].excerpt[language]}
+                      {articles[0].excerpt.en}
                     </p>
                     
                     <div className="flex items-center gap-2">
-                      {articles[0].tags[language].slice(0, 3).map((tag) => (
+                      {articles[0].tags.en.slice(0, 3).map((tag) => (
                         <span
                           key={tag}
                           className="px-3 py-1 bg-muted text-muted-foreground rounded-md text-sm"
@@ -122,7 +100,7 @@ export default function BlogPage() {
                 <div className="h-full flex flex-col overflow-hidden rounded-xl bg-card border border-border hover:border-primary/50 transition-all duration-300 hover:shadow-lg hover:-translate-y-1">
                   <div className="flex-1 p-6 flex flex-col">
                     <span className="inline-block px-2 py-1 bg-primary/10 text-primary text-xs font-medium rounded mb-3 self-start">
-                      {article.category[language]}
+                      {article.category.en}
                     </span>
                     
                     <div className="flex items-center gap-3 text-sm text-muted-foreground mb-3">
@@ -135,21 +113,21 @@ export default function BlogPage() {
                       </span>
                       <span className="flex items-center gap-1">
                         <Clock className="h-3 w-3" />
-                        {article.readTime[language]}
+                        {article.readTime.en}
                       </span>
                     </div>
                     
                     <h3 className="text-xl font-semibold mb-2 line-clamp-2 group-hover:text-primary transition-colors">
-                      {article.title[language]}
+                      {article.title.en}
                     </h3>
                     
                     <p className="text-muted-foreground mb-4 line-clamp-3 flex-1">
-                      {article.excerpt[language]}
+                      {article.excerpt.en}
                     </p>
                     
                     <div className="flex items-center justify-between mt-auto pt-4 border-t">
                       <div className="flex flex-wrap gap-2">
-                        {article.tags[language].slice(0, 2).map((tag) => (
+                        {article.tags.en.slice(0, 2).map((tag) => (
                           <span
                             key={tag}
                             className="px-2 py-1 bg-muted text-muted-foreground rounded text-xs"

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { motion } from "framer-motion";
 import { fadeInUp, staggerChildren } from "@/lib/motion-variants";
 import { useAnalytics } from "@/hooks/useAnalytics";
@@ -20,118 +20,59 @@ import {
 } from "lucide-react";
 
 export default function ContactPage() {
-  const [language, setLanguage] = useState<"en" | "ar">("en");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const { trackContactForm } = useAnalytics();
 
-  useEffect(() => {
-    const savedLang = localStorage.getItem("language") as "en" | "ar";
-    if (savedLang) {
-      setLanguage(savedLang);
-      document.documentElement.dir = savedLang === "ar" ? "rtl" : "ltr";
-    }
-  }, []);
-
   const content = {
-    en: {
-      hero: {
-        title: "Let's Start a",
-        titleHighlight: "Conversation",
-        subtitle: "Ready to transform your security infrastructure? Our team is here to help you explore how Triya.ai can meet your specific needs."
-      },
-      form: {
-        title: "Send us a message",
-        description: "",
-        fields: {
-          name: "Full Name",
-          email: "Email Address",
-          company: "Company Name",
-          phone: "Phone Number",
-          message: "Message",
-          messagePlaceholder: "Tell us about your security needs..."
-        },
-        submit: "Send Message"
-      },
-      contact: {
-        title: "Get in touch",
-        methods: [
-          {
-            icon: Mail,
-            title: "Email",
-            description: "For general inquiries",
-            detail: "founders@triya.ai"
-          },
-          {
-            icon: Phone,
-            title: "Phone",
-            description: "",
-            detail: "+971-58-680-1200"
-          },
-          {
-            icon: Building,
-            title: "Registered",
-            description: "Abu Dhabi Global Market",
-            detail: "Al Maryah Island, UAE"
-          }
-        ]
-      },
-      cta: {
-        title: "Ready for a Demo?",
-        description: "See Triya.ai in action with a personalized demonstration",
-        button: "Schedule Demo"
-      }
+    hero: {
+      title: "Let's Start a",
+      titleHighlight: "Conversation",
+      subtitle: "Ready to transform your security infrastructure? Our team is here to help you explore how Triya.ai can meet your specific needs."
     },
-    ar: {
-      hero: {
-        title: "لنبدأ",
-        titleHighlight: "محادثة",
-        subtitle: "هل أنت مستعد لتحويل البنية التحتية الأمنية الخاصة بك؟ فريقنا هنا لمساعدتك في استكشاف كيف يمكن لـ Triya.ai تلبية احتياجاتك المحددة."
+    form: {
+      title: "Send us a message",
+      description: "",
+      fields: {
+        name: "Full Name",
+        email: "Email Address",
+        company: "Company Name",
+        phone: "Phone Number",
+        message: "Message",
+        messagePlaceholder: "Tell us about your security needs..."
       },
-      form: {
-        title: "أرسل لنا رسالة",
-        description: "",
-        fields: {
-          name: "الاسم الكامل",
-          email: "عنوان البريد الإلكتروني",
-          company: "اسم الشركة",
-          phone: "رقم الهاتف",
-          message: "الرسالة",
-          messagePlaceholder: "أخبرنا عن احتياجاتك الأمنية..."
+      submit: "Send Message"
+    },
+    contact: {
+      title: "Get in touch",
+      methods: [
+        {
+          icon: Mail,
+          title: "Email",
+          description: "For general inquiries",
+          detail: "founders@triya.ai"
         },
-        submit: "إرسال الرسالة"
-      },
-      contact: {
-        title: "تواصل معنا",
-        methods: [
-          {
-            icon: Mail,
-            title: "البريد الإلكتروني",
-            description: "للاستفسارات العامة",
-            detail: "founders@triya.ai"
-          },
-          {
-            icon: Phone,
-            title: "الهاتف",
-            description: "",
-            detail: "+971-58-680-1200"
-          },
-          {
-            icon: Building,
-            title: "مسجل",
-            description: "سوق أبوظبي العالمي",
-            detail: "جزيرة المارية، الإمارات"
-          }
-        ]
-      },
-      cta: {
-        title: "جاهز لعرض توضيحي؟",
-        description: "شاهد Triya.ai في العمل مع عرض توضيحي شخصي",
-        button: "جدولة عرض توضيحي"
-      }
+        {
+          icon: Phone,
+          title: "Phone",
+          description: "",
+          detail: "+971-58-680-1200"
+        },
+        {
+          icon: Building,
+          title: "Registered",
+          description: "Abu Dhabi Global Market",
+          detail: "Al Maryah Island, UAE"
+        }
+      ]
+    },
+    cta: {
+      title: "Ready for a Demo?",
+      description: "See Triya.ai in action with a personalized demonstration",
+      button: "Schedule Demo"
     }
   };
 
-  const t = content[language];
+  const t = content;
   
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();

--- a/app/faq/faq-data.ts
+++ b/app/faq/faq-data.ts
@@ -1,318 +1,129 @@
 export interface FAQItem {
-  question: {
-    en: string;
-    ar: string;
-  };
-  answer: {
-    en: string;
-    ar: string;
-  };
-  category: {
-    en: string;
-    ar: string;
-  };
+  question: string;
+  answer: string;
+  category: string;
 }
 
 export const faqData: FAQItem[] = [
   // Product & Features
   {
-    category: {
-      en: "Product & Features",
-      ar: "المنتج والميزات"
-    },
-    question: {
-      en: "What is Triya's edge AI surveillance platform?",
-      ar: "ما هي منصة المراقبة بالذكاء الاصطناعي من تريا؟"
-    },
-    answer: {
-      en: "Triya is an advanced AI-powered video analytics platform that transforms any camera into an intelligent security system. It processes video data on-premise using edge computing, providing real-time alerts, object detection, and behavioral analysis while maintaining complete data privacy.",
-      ar: "تريا هي منصة متقدمة لتحليل الفيديو بالذكاء الاصطناعي تحول أي كاميرا إلى نظام أمني ذكي. تعالج بيانات الفيديو محلياً باستخدام الحوسبة الطرفية، وتوفر تنبيهات فورية واكتشاف الأجسام وتحليل السلوك مع الحفاظ على خصوصية البيانات الكاملة."
-    }
+    category: "Product & Features",
+    question: "What is Triya's edge AI surveillance platform?",
+    answer: "Triya is an advanced AI-powered video analytics platform that transforms any camera into an intelligent security system. It processes video data on-premise using edge computing, providing real-time alerts, object detection, and behavioral analysis while maintaining complete data privacy."
   },
   {
-    category: {
-      en: "Product & Features",
-      ar: "المنتج والميزات"
-    },
-    question: {
-      en: "How does Triya reduce surveillance costs by 85%?",
-      ar: "كيف تقلل تريا من تكاليف المراقبة بنسبة 85%؟"
-    },
-    answer: {
-      en: "Triya reduces costs through multiple factors: eliminating expensive cloud storage fees, reducing bandwidth requirements by processing data locally, preventing losses through real-time alerts, and working with existing camera infrastructure without requiring hardware replacement.",
-      ar: "تقلل تريا التكاليف من خلال عوامل متعددة: إلغاء رسوم التخزين السحابي المكلفة، وتقليل متطلبات النطاق الترددي من خلال معالجة البيانات محلياً، ومنع الخسائر من خلال التنبيهات الفورية، والعمل مع البنية التحتية للكاميرات الحالية دون الحاجة لاستبدال الأجهزة."
-    }
+    category: "Product & Features",
+    question: "How does Triya reduce surveillance costs by 85%?",
+    answer: "Triya reduces costs through multiple factors: eliminating expensive cloud storage fees, reducing bandwidth requirements by processing data locally, preventing losses through real-time alerts, and working with existing camera infrastructure without requiring hardware replacement."
   },
   {
-    category: {
-      en: "Product & Features",
-      ar: "المنتج والميزات"
-    },
-    question: {
-      en: "Does Triya work with existing security cameras?",
-      ar: "هل تعمل تريا مع كاميرات الأمان الحالية؟"
-    },
-    answer: {
-      en: "Yes, Triya is camera-agnostic and compatible with most IP cameras, CCTV systems, and webcams. Our platform integrates seamlessly with your existing infrastructure, eliminating the need for costly camera replacements.",
-      ar: "نعم، تريا متوافقة مع جميع أنواع الكاميرات وتعمل مع معظم كاميرات IP وأنظمة CCTV وكاميرات الويب. تتكامل منصتنا بسلاسة مع البنية التحتية الحالية لديك، مما يلغي الحاجة لاستبدال الكاميرات المكلف."
-    }
+    category: "Product & Features",
+    question: "Does Triya work with existing security cameras?",
+    answer: "Yes, Triya is camera-agnostic and compatible with most IP cameras, CCTV systems, and webcams. Our platform integrates seamlessly with your existing infrastructure, eliminating the need for costly camera replacements."
   },
   {
-    category: {
-      en: "Product & Features",
-      ar: "المنتج والميزات"
-    },
-    question: {
-      en: "What makes Triya different from traditional CCTV systems?",
-      ar: "ما الذي يميز تريا عن أنظمة المراقبة التقليدية؟"
-    },
-    answer: {
-      en: "Unlike passive CCTV that only records, Triya actively analyzes video in real-time, detecting threats, unusual behaviors, and specific events instantly. It provides intelligent alerts, supports 30+ languages including Arabic, and processes everything on-premise for complete privacy.",
-      ar: "بخلاف أنظمة المراقبة التقليدية التي تسجل فقط، تحلل تريا الفيديو بنشاط في الوقت الفعلي، وتكتشف التهديدات والسلوكيات غير العادية والأحداث المحددة فوراً. توفر تنبيهات ذكية، وتدعم أكثر من 30 لغة بما فيها العربية، وتعالج كل شيء محلياً للحفاظ على الخصوصية الكاملة."
-    }
+    category: "Product & Features",
+    question: "What makes Triya different from traditional CCTV systems?",
+    answer: "Unlike passive CCTV that only records, Triya actively analyzes video in real-time, detecting threats, unusual behaviors, and specific events instantly. It provides intelligent alerts, supports 30+ languages including Arabic, and processes everything on-premise for complete privacy."
   },
   {
-    category: {
-      en: "Product & Features",
-      ar: "المنتج والميزات"
-    },
-    question: {
-      en: "Can Triya detect specific objects or behaviors?",
-      ar: "هل يمكن لتريا اكتشاف أجسام أو سلوكيات محددة؟"
-    },
-    answer: {
-      en: "Yes, Triya can detect people, vehicles, license plates, PPE compliance, crowd density, loitering, intrusion, abandoned objects, and many custom scenarios. Our AI models are continuously updated to recognize new patterns and behaviors.",
-      ar: "نعم، يمكن لتريا اكتشاف الأشخاص والمركبات ولوحات الأرقام والامتثال لمعدات الحماية الشخصية وكثافة الحشود والتسكع والاقتحام والأجسام المهجورة والعديد من السيناريوهات المخصصة. يتم تحديث نماذج الذكاء الاصطناعي لدينا باستمرار للتعرف على أنماط وسلوكيات جديدة."
-    }
+    category: "Product & Features",
+    question: "Can Triya detect specific objects or behaviors?",
+    answer: "Yes, Triya can detect people, vehicles, license plates, PPE compliance, crowd density, loitering, intrusion, abandoned objects, and many custom scenarios. Our AI models are continuously updated to recognize new patterns and behaviors."
   },
-  
+
   // Technical & Implementation
   {
-    category: {
-      en: "Technical & Implementation",
-      ar: "التقنية والتنفيذ"
-    },
-    question: {
-      en: "What are the system requirements for Triya?",
-      ar: "ما هي متطلبات النظام لتريا؟"
-    },
-    answer: {
-      en: "Triya requires a standard server or edge device with GPU support for optimal performance. We support Windows, Linux, and can run on various hardware from desktop computers to specialized edge computing devices. Our team provides detailed specifications based on your camera count and requirements.",
-      ar: "تتطلب تريا خادماً قياسياً أو جهاز حوسبة طرفية مع دعم GPU للحصول على أفضل أداء. ندعم Windows وLinux ويمكن التشغيل على أجهزة متنوعة من أجهزة الكمبيوتر المكتبية إلى أجهزة الحوسبة الطرفية المتخصصة. يوفر فريقنا مواصفات مفصلة بناءً على عدد الكاميرات ومتطلباتك."
-    }
+    category: "Technical & Implementation",
+    question: "What are the system requirements for Triya?",
+    answer: "Triya requires a standard server or edge device with GPU support for optimal performance. We support Windows, Linux, and can run on various hardware from desktop computers to specialized edge computing devices. Our team provides detailed specifications based on your camera count and requirements."
   },
   {
-    category: {
-      en: "Technical & Implementation",
-      ar: "التقنية والتنفيذ"
-    },
-    question: {
-      en: "How long does Triya installation take?",
-      ar: "كم يستغرق تثبيت تريا؟"
-    },
-    answer: {
-      en: "Basic installation typically takes 2-4 hours for up to 10 cameras. Larger deployments may take 1-2 days depending on the number of cameras and integration requirements. Our team handles the entire setup process including configuration and testing.",
-      ar: "يستغرق التثبيت الأساسي عادة 2-4 ساعات لما يصل إلى 10 كاميرات. قد تستغرق التثبيتات الأكبر 1-2 يوم حسب عدد الكاميرات ومتطلبات التكامل. يتولى فريقنا عملية الإعداد الكاملة بما في ذلك التكوين والاختبار."
-    }
+    category: "Technical & Implementation",
+    question: "How long does Triya installation take?",
+    answer: "Basic installation typically takes 2-4 hours for up to 10 cameras. Larger deployments may take 1-2 days depending on the number of cameras and integration requirements. Our team handles the entire setup process including configuration and testing."
   },
   {
-    category: {
-      en: "Technical & Implementation",
-      ar: "التقنية والتنفيذ"
-    },
-    question: {
-      en: "Is internet connection required for Triya to work?",
-      ar: "هل الاتصال بالإنترنت مطلوب لعمل تريا؟"
-    },
-    answer: {
-      en: "No, Triya operates completely offline using edge computing. Internet is only needed for optional features like remote monitoring, software updates, and cloud backup. The core AI surveillance functions work without any internet connection.",
-      ar: "لا، تعمل تريا بشكل كامل دون اتصال بالإنترنت باستخدام الحوسبة الطرفية. الإنترنت مطلوب فقط للميزات الاختيارية مثل المراقبة عن بعد والتحديثات البرمجية والنسخ الاحتياطي السحابي. تعمل وظائف المراقبة الأساسية بالذكاء الاصطناعي دون أي اتصال بالإنترنت."
-    }
+    category: "Technical & Implementation",
+    question: "Is internet connection required for Triya to work?",
+    answer: "No, Triya operates completely offline using edge computing. Internet is only needed for optional features like remote monitoring, software updates, and cloud backup. The core AI surveillance functions work without any internet connection."
   },
   {
-    category: {
-      en: "Technical & Implementation",
-      ar: "التقنية والتنفيذ"
-    },
-    question: {
-      en: "What video formats and resolutions does Triya support?",
-      ar: "ما هي تنسيقات الفيديو والدقة التي تدعمها تريا؟"
-    },
-    answer: {
-      en: "Triya supports all major video formats including H.264, H.265, MJPEG, and RTSP streams. We handle resolutions from 480p to 4K, automatically optimizing processing based on your requirements and available computing resources.",
-      ar: "تدعم تريا جميع تنسيقات الفيديو الرئيسية بما في ذلك H.264 وH.265 وMJPEG وتدفقات RTSP. نتعامل مع دقة من 480p إلى 4K، مع تحسين المعالجة تلقائياً بناءً على متطلباتك وموارد الحوسبة المتاحة."
-    }
+    category: "Technical & Implementation",
+    question: "What video formats and resolutions does Triya support?",
+    answer: "Triya supports all major video formats including H.264, H.265, MJPEG, and RTSP streams. We handle resolutions from 480p to 4K, automatically optimizing processing based on your requirements and available computing resources."
   },
   {
-    category: {
-      en: "Technical & Implementation",
-      ar: "التقنية والتنفيذ"
-    },
-    question: {
-      en: "Can Triya integrate with existing security systems?",
-      ar: "هل يمكن لتريا التكامل مع أنظمة الأمان الحالية؟"
-    },
-    answer: {
-      en: "Yes, Triya provides APIs and webhooks for integration with access control systems, alarm systems, and security management platforms. We support standard protocols and can customize integrations for enterprise requirements.",
-      ar: "نعم، توفر تريا واجهات برمجة التطبيقات APIs وwebhooks للتكامل مع أنظمة التحكم في الوصول وأنظمة الإنذار ومنصات إدارة الأمن. ندعم البروتوكولات القياسية ويمكننا تخصيص التكاملات لمتطلبات المؤسسات."
-    }
+    category: "Technical & Implementation",
+    question: "Can Triya integrate with existing security systems?",
+    answer: "Yes, Triya provides APIs and webhooks for integration with access control systems, alarm systems, and security management platforms. We support standard protocols and can customize integrations for enterprise requirements."
   },
-  
+
   // Pricing & Support
   {
-    category: {
-      en: "Pricing & Support",
-      ar: "الأسعار والدعم"
-    },
-    question: {
-      en: "How much does Triya cost?",
-      ar: "كم تكلفة تريا؟"
-    },
-    answer: {
-      en: "Triya offers flexible pricing based on the number of cameras and features required. Our solutions typically cost 85% less than cloud-based alternatives. Contact us for a customized quote based on your specific needs and deployment size.",
-      ar: "تقدم تريا أسعاراً مرنة بناءً على عدد الكاميرات والميزات المطلوبة. تكلف حلولنا عادة أقل بنسبة 85% من البدائل السحابية. اتصل بنا للحصول على عرض سعر مخصص بناءً على احتياجاتك المحددة وحجم التثبيت."
-    }
+    category: "Pricing & Support",
+    question: "How much does Triya cost?",
+    answer: "Triya offers flexible pricing based on the number of cameras and features required. Our solutions typically cost 85% less than cloud-based alternatives. Contact us for a customized quote based on your specific needs and deployment size."
   },
   {
-    category: {
-      en: "Pricing & Support",
-      ar: "الأسعار والدعم"
-    },
-    question: {
-      en: "Is there a free trial or demo available?",
-      ar: "هل يتوفر عرض تجريبي أو تجربة مجانية؟"
-    },
-    answer: {
-      en: "Yes, we offer a comprehensive demo where we'll show Triya working with your actual cameras and use cases. We also provide proof-of-concept deployments for enterprise clients to evaluate the platform in their environment.",
-      ar: "نعم، نقدم عرضاً توضيحياً شاملاً حيث سنعرض عمل تريا مع كاميراتك الفعلية وحالات الاستخدام الخاصة بك. كما نوفر تثبيتات إثبات المفهوم للعملاء من المؤسسات لتقييم المنصة في بيئتهم."
-    }
+    category: "Pricing & Support",
+    question: "Is there a free trial or demo available?",
+    answer: "Yes, we offer a comprehensive demo where we'll show Triya working with your actual cameras and use cases. We also provide proof-of-concept deployments for enterprise clients to evaluate the platform in their environment."
   },
   {
-    category: {
-      en: "Pricing & Support",
-      ar: "الأسعار والدعم"
-    },
-    question: {
-      en: "What support options are available?",
-      ar: "ما هي خيارات الدعم المتاحة؟"
-    },
-    answer: {
-      en: "We provide multiple support tiers including email support, phone support, and 24/7 dedicated support for enterprise clients. All plans include software updates, and we offer both remote and on-site support options across the GCC region.",
-      ar: "نوفر مستويات دعم متعددة بما في ذلك الدعم عبر البريد الإلكتروني والدعم الهاتفي والدعم المخصص على مدار الساعة للعملاء من المؤسسات. تتضمن جميع الخطط تحديثات البرامج، ونقدم خيارات الدعم عن بعد وفي الموقع عبر منطقة دول مجلس التعاون الخليجي."
-    }
+    category: "Pricing & Support",
+    question: "What support options are available?",
+    answer: "We provide multiple support tiers including email support, phone support, and 24/7 dedicated support for enterprise clients. All plans include software updates, and we offer both remote and on-site support options across the GCC region."
   },
   {
-    category: {
-      en: "Pricing & Support",
-      ar: "الأسعار والدعم"
-    },
-    question: {
-      en: "Do you provide training for our security team?",
-      ar: "هل تقدمون تدريباً لفريق الأمن لدينا؟"
-    },
-    answer: {
-      en: "Yes, we provide comprehensive training covering system operation, alert management, and report generation. Training can be conducted on-site or remotely, with materials available in English and Arabic.",
-      ar: "نعم، نقدم تدريباً شاملاً يغطي تشغيل النظام وإدارة التنبيهات وإنشاء التقارير. يمكن إجراء التدريب في الموقع أو عن بعد، مع توفر المواد التدريبية باللغتين الإنجليزية والعربية."
-    }
+    category: "Pricing & Support",
+    question: "Do you provide training for our security team?",
+    answer: "Yes, we provide comprehensive training covering system operation, alert management, and report generation. Training can be conducted on-site or remotely, with materials available in English and Arabic."
   },
-  
+
   // Location & Availability
   {
-    category: {
-      en: "Location & Availability",
-      ar: "الموقع والتوافر"
-    },
-    question: {
-      en: "Do you provide local installation in UAE?",
-      ar: "هل تقدمون التثبيت المحلي في دولة الإمارات؟"
-    },
-    answer: {
-      en: "Yes, we have local teams in Abu Dhabi and Dubai providing same-day installation and support services throughout the UAE. Our headquarters is located in Abu Dhabi Global Market (ADGM).",
-      ar: "نعم، لدينا فرق محلية في أبوظبي ودبي تقدم خدمات التثبيت والدعم في نفس اليوم في جميع أنحاء دولة الإمارات. يقع مقرنا الرئيسي في سوق أبوظبي العالمي (ADGM)."
-    }
+    category: "Location & Availability",
+    question: "Do you provide local installation in UAE?",
+    answer: "Yes, we have local teams in Abu Dhabi and Dubai providing same-day installation and support services throughout the UAE. Our headquarters is located in Abu Dhabi Global Market (ADGM)."
   },
   {
-    category: {
-      en: "Location & Availability",
-      ar: "الموقع والتوافر"
-    },
-    question: {
-      en: "How fast can you deploy Triya in Dubai or Abu Dhabi?",
-      ar: "ما هي سرعة نشر تريا في دبي أو أبوظبي؟"
-    },
-    answer: {
-      en: "For standard deployments in Dubai and Abu Dhabi, we can typically install and configure Triya within 24-48 hours of approval. Emergency deployments can be arranged for critical security needs with same-day service available.",
-      ar: "للتثبيتات القياسية في دبي وأبوظبي، يمكننا عادة تثبيت وتكوين تريا خلال 24-48 ساعة من الموافقة. يمكن ترتيب التثبيتات الطارئة لاحتياجات الأمن الحرجة مع توفر الخدمة في نفس اليوم."
-    }
+    category: "Location & Availability",
+    question: "How fast can you deploy Triya in Dubai or Abu Dhabi?",
+    answer: "For standard deployments in Dubai and Abu Dhabi, we can typically install and configure Triya within 24-48 hours of approval. Emergency deployments can be arranged for critical security needs with same-day service available."
   },
   {
-    category: {
-      en: "Location & Availability",
-      ar: "الموقع والتوافر"
-    },
-    question: {
-      en: "Which countries does Triya serve?",
-      ar: "ما هي الدول التي تخدمها تريا؟"
-    },
-    answer: {
-      en: "We primarily serve the GCC region including UAE, Saudi Arabia, Qatar, Kuwait, Bahrain, and Oman. We're expanding across the broader Middle East and North Africa region with local partners.",
-      ar: "نخدم بشكل أساسي منطقة دول مجلس التعاون الخليجي بما في ذلك الإمارات والسعودية وقطر والكويت والبحرين وعمان. نحن نتوسع عبر منطقة الشرق الأوسط وشمال أفريقيا الأوسع مع شركاء محليين."
-    }
+    category: "Location & Availability",
+    question: "Which countries does Triya serve?",
+    answer: "We primarily serve the GCC region including UAE, Saudi Arabia, Qatar, Kuwait, Bahrain, and Oman. We're expanding across the broader Middle East and North Africa region with local partners."
   },
   {
-    category: {
-      en: "Location & Availability",
-      ar: "الموقع والتوافر"
-    },
-    question: {
-      en: "Is on-site support available in my area?",
-      ar: "هل الدعم في الموقع متاح في منطقتي؟"
-    },
-    answer: {
-      en: "We provide on-site support across major cities in the GCC including Abu Dhabi, Dubai, Riyadh, Doha, Kuwait City, and Muscat. For other locations, we offer remote support and work with certified local partners.",
-      ar: "نوفر الدعم في الموقع عبر المدن الرئيسية في دول مجلس التعاون الخليجي بما في ذلك أبوظبي ودبي والرياض والدوحة ومدينة الكويت ومسقط. للمواقع الأخرى، نقدم الدعم عن بعد ونعمل مع شركاء محليين معتمدين."
-    }
+    category: "Location & Availability",
+    question: "Is on-site support available in my area?",
+    answer: "We provide on-site support across major cities in the GCC including Abu Dhabi, Dubai, Riyadh, Doha, Kuwait City, and Muscat. For other locations, we offer remote support and work with certified local partners."
   },
-  
+
   // Privacy & Security
   {
-    category: {
-      en: "Privacy & Security",
-      ar: "الخصوصية والأمان"
-    },
-    question: {
-      en: "How is video data stored and protected?",
-      ar: "كيف يتم تخزين بيانات الفيديو وحمايتها؟"
-    },
-    answer: {
-      en: "All video data is processed and stored on-premise on your own servers, giving you complete control. Data is encrypted using AES-256 encryption, and we never have access to your video feeds or stored data unless explicitly authorized for support.",
-      ar: "تتم معالجة جميع بيانات الفيديو وتخزينها محلياً على خوادمك الخاصة، مما يمنحك التحكم الكامل. يتم تشفير البيانات باستخدام تشفير AES-256، ولا يمكننا الوصول إلى موجزات الفيديو أو البيانات المخزنة إلا بتصريح صريح للدعم."
-    }
+    category: "Privacy & Security",
+    question: "How is video data stored and protected?",
+    answer: "All video data is processed and stored on-premise on your own servers, giving you complete control. Data is encrypted using AES-256 encryption, and we never have access to your video feeds or stored data unless explicitly authorized for support."
   },
   {
-    category: {
-      en: "Privacy & Security",
-      ar: "الخصوصية والأمان"
-    },
-    question: {
-      en: "Does Triya comply with data protection regulations?",
-      ar: "هل تمتثل تريا للوائح حماية البيانات؟"
-    },
-    answer: {
-      en: "Yes, Triya is designed for complete regulatory compliance. By processing data on-premise, we help organizations meet GDPR, local data sovereignty requirements, and industry-specific regulations while maintaining the highest security standards.",
-      ar: "نعم، تريا مصممة للامتثال التنظيمي الكامل. من خلال معالجة البيانات محلياً، نساعد المؤسسات على تلبية متطلبات GDPR ومتطلبات سيادة البيانات المحلية واللوائح الخاصة بالصناعة مع الحفاظ على أعلى معايير الأمان."
-    }
+    category: "Privacy & Security",
+    question: "Does Triya comply with data protection regulations?",
+    answer: "Yes, Triya is designed for complete regulatory compliance. By processing data on-premise, we help organizations meet GDPR, local data sovereignty requirements, and industry-specific regulations while maintaining the highest security standards."
   }
 ];
 
 // Helper function to get FAQs by category
-export function getFAQsByCategory(category: string, language: "en" | "ar" = "en"): FAQItem[] {
-  return faqData.filter(faq => faq.category[language] === category);
+export function getFAQsByCategory(category: string): FAQItem[] {
+  return faqData.filter(faq => faq.category === category);
 }
 
 // Helper function to get all unique categories
-export function getCategories(language: "en" | "ar" = "en"): string[] {
-  return Array.from(new Set(faqData.map(faq => faq.category[language])));
+export function getCategories(): string[] {
+  return Array.from(new Set(faqData.map(faq => faq.category)));
 }
 
 // Generate FAQ Schema for SEO
@@ -322,10 +133,10 @@ export function generateFAQSchema() {
     "@type": "FAQPage",
     "mainEntity": faqData.map(faq => ({
       "@type": "Question",
-      "name": faq.question.en,
+      "name": faq.question,
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": faq.answer.en
+        "text": faq.answer
       }
     }))
   };

--- a/app/faq/page.tsx
+++ b/app/faq/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { ChevronDown, ChevronUp, ArrowRight, ArrowLeft } from "lucide-react";
+import { useState } from "react";
+import { ChevronDown, ArrowRight } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 import { faqData, getCategories } from "./faq-data";
 import { fadeInUp, staggerChildren } from "@/lib/motion-variants";
@@ -9,47 +9,27 @@ import { Breadcrumbs } from "@/components/shared/breadcrumbs";
 
 export default function FAQPage() {
   const [openItems, setOpenItems] = useState<number[]>([]);
-  const [language, setLanguage] = useState<"en" | "ar">("en");
 
-  useEffect(() => {
-    // Check for saved language preference
-    const savedLang = localStorage.getItem("language") as "en" | "ar";
-    if (savedLang) {
-      setLanguage(savedLang);
-      document.documentElement.dir = savedLang === "ar" ? "rtl" : "ltr";
-    }
-  }, []);
-
-  const categories = getCategories(language);
+  const categories = getCategories();
 
   const toggleItem = (index: number) => {
-    setOpenItems(prev => 
-      prev.includes(index) 
+    setOpenItems(prev =>
+      prev.includes(index)
         ? prev.filter(i => i !== index)
         : [...prev, index]
     );
   };
 
   const content = {
-    en: {
-      title: "Frequently Asked Questions",
-      subtitle: "Everything you need to know about Triya's AI surveillance platform",
-      ctaTitle: "Still have questions?",
-      ctaSubtitle: "Our team is here to help you understand how Triya can transform your security operations.",
-      ctaButton: "Contact Us"
-    },
-    ar: {
-      title: "الأسئلة الشائعة",
-      subtitle: "كل ما تحتاج لمعرفته حول منصة المراقبة بالذكاء الاصطناعي من تريا",
-      ctaTitle: "هل لديك أسئلة أخرى؟",
-      ctaSubtitle: "فريقنا هنا لمساعدتك على فهم كيف يمكن لتريا تحويل عمليات الأمن لديك.",
-      ctaButton: "اتصل بنا"
-    }
+    title: "Frequently Asked Questions",
+    subtitle: "Everything you need to know about Triya's AI surveillance platform",
+    ctaTitle: "Still have questions?",
+    ctaSubtitle: "Our team is here to help you understand how Triya can transform your security operations.",
+    ctaButton: "Contact Us"
   };
 
-  const t = content[language];
-  const ChevronIcon = language === "ar" ? ChevronUp : ChevronDown;
-  const ArrowIcon = language === "ar" ? ArrowLeft : ArrowRight;
+  const t = content;
+  const ChevronIcon = ChevronDown;
 
   return (
     <>
@@ -81,11 +61,11 @@ export default function FAQPage() {
                 </h2>
                 <div className="space-y-4">
                   {faqData
-                    .filter(faq => faq.category[language] === category)
+                    .filter(faq => faq.category === category)
                     .map((faq, index) => {
                       const globalIndex = faqData.indexOf(faq);
                       const isOpen = openItems.includes(globalIndex);
-                      
+
                       return (
                         <div
                           key={globalIndex}
@@ -93,12 +73,12 @@ export default function FAQPage() {
                         >
                           <button
                             onClick={() => toggleItem(globalIndex)}
-                            className={`w-full px-6 py-4 text-${language === 'ar' ? 'right' : 'left'} flex items-center justify-between hover:bg-muted/50 transition-colors`}
+                            className="w-full px-6 py-4 text-left flex items-center justify-between hover:bg-muted/50 transition-colors"
                           >
-                            <span className="font-medium pr-4">{faq.question[language]}</span>
+                            <span className="font-medium pr-4">{faq.question}</span>
                             <ChevronIcon
                               className={`h-5 w-5 flex-shrink-0 transition-transform duration-200 ${
-                                isOpen ? (language === "ar" ? "" : "rotate-180") : (language === "ar" ? "rotate-180" : "")
+                                isOpen ? "rotate-180" : ""
                               }`}
                             />
                           </button>
@@ -111,8 +91,8 @@ export default function FAQPage() {
                                 transition={{ duration: 0.2 }}
                                 className="overflow-hidden"
                               >
-                                <div className={`px-6 pb-4 text-muted-foreground text-${language === 'ar' ? 'right' : 'left'}`}>
-                                  {faq.answer[language]}
+                                <div className="px-6 pb-4 text-muted-foreground text-left">
+                                  {faq.answer}
                                 </div>
                               </motion.div>
                             )}
@@ -126,7 +106,7 @@ export default function FAQPage() {
           </motion.div>
 
           {/* CTA Section */}
-          <motion.div 
+          <motion.div
             variants={fadeInUp}
             className="mt-16 text-center p-8 bg-muted/30 rounded-lg"
           >
@@ -141,11 +121,7 @@ export default function FAQPage() {
               className="inline-flex items-center justify-center gap-2 px-6 py-3 bg-primary text-primary-foreground rounded-md hover:bg-primary/90 transition-colors"
             >
               {t.ctaButton}
-              {language === "ar" ? (
-                <ArrowLeft className="h-4 w-4" />
-              ) : (
-                <ArrowRight className="h-4 w-4" />
-              )}
+              <ArrowRight className="h-4 w-4" />
             </a>
           </motion.div>
         </motion.div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import { ArrowRight, Play, Globe, X } from "lucide-react";
+import { ArrowRight, Play, X } from "lucide-react";
 import Link from "next/link";
 import { useState, useEffect } from "react";
 import { useAnalytics } from "@/hooks/useAnalytics";
@@ -21,7 +21,6 @@ import { motion } from "framer-motion";
 import { fadeInUp, fadeIn, staggerChildren } from "@/lib/motion-variants";
 
 export default function Home() {
-  const [language, setLanguage] = useState<"en" | "ar">("en");
   const [mounted, setMounted] = useState(false);
   const [showVideoModal, setShowVideoModal] = useState(false);
   const [videoLoaded, setVideoLoaded] = useState(false);
@@ -29,54 +28,30 @@ export default function Home() {
 
   useEffect(() => {
     setMounted(true);
-    // Check for saved language preference
-    const savedLang = localStorage.getItem("language") as "en" | "ar";
-    if (savedLang) {
-      setLanguage(savedLang);
-    }
-    
+
     // Lazy load video when user is likely to see it
     const loadVideo = () => {
       setVideoLoaded(true);
     };
-    
+
     // Load video after initial render
     const timer = setTimeout(loadVideo, 100);
-    
+
     return () => clearTimeout(timer);
   }, []);
 
-  const toggleLanguage = () => {
-    const newLang = language === "en" ? "ar" : "en";
-    setLanguage(newLang);
-    localStorage.setItem("language", newLang);
-    document.documentElement.dir = newLang === "ar" ? "rtl" : "ltr";
-  };
-
   const content = {
-    en: {
-      hero: {
-        title: "UAE's Leading",
-        titleHighlight: "Edge AI Surveillance Platform",
-        subtitle: "Transform any camera into an intelligent security system. 85% cost savings. Serving Dubai, Abu Dhabi, and the entire GCC region.",
-        cta1: "Request Demo",
-        cta2: "Watch Video"
-      },
-      trust: "Trusted by leading organizations across the GCC"
+    hero: {
+      title: "UAE's Leading",
+      titleHighlight: "Edge AI Surveillance Platform",
+      subtitle: "Transform any camera into an intelligent security system. 85% cost savings. Serving Dubai, Abu Dhabi, and the entire GCC region.",
+      cta1: "Request Demo",
+      cta2: "Watch Video"
     },
-    ar: {
-      hero: {
-        title: "منصة الإمارات الرائدة",
-        titleHighlight: "للمراقبة بالذكاء الاصطناعي",
-        subtitle: "حوّل أي كاميرا إلى نظام أمني ذكي. توفير 85% من التكاليف. نخدم دبي وأبوظبي ومنطقة الخليج.",
-        cta1: "طلب عرض توضيحي",
-        cta2: "شاهد الفيديو"
-      },
-      trust: "موثوق من قبل المؤسسات الرائدة في دول مجلس التعاون الخليجي"
-    }
+    trust: "Trusted by leading organizations across the GCC"
   };
 
-  const t = content[language];
+  const t = content;
 
   if (!mounted) {
     return null;
@@ -85,19 +60,6 @@ export default function Home() {
   return (
     <div className="flex flex-col">
       <ProductSchema />
-      {/* Language Toggle */}
-      <div className="fixed top-20 right-4 z-50">
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={toggleLanguage}
-          className="gap-2"
-        >
-          <Globe className="h-4 w-4" />
-          {language === "en" ? "العربية" : "English"}
-        </Button>
-      </div>
-
       {/* Hero Section */}
       <section className="relative min-h-[100dvh] md:h-[75vh] flex items-center justify-center overflow-hidden py-20 md:py-0">
         {/* Video Background Container */}
@@ -186,16 +148,16 @@ export default function Home() {
       </section> */}
 
       {/* Product Showcase */}
-      <ProductShowcase language={language} />
+      <ProductShowcase />
 
       {/* How It Works */}
-      <HowItWorks language={language} />
+      <HowItWorks />
 
       {/* Use Cases */}
-      <UseCases language={language} />
+      <UseCases />
 
       {/* CTA Section */}
-      <CTASection language={language} />
+      <CTASection />
 
       {/* Video Modal */}
       <Dialog open={showVideoModal} onOpenChange={setShowVideoModal}>

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,22 +1,11 @@
 "use client";
 
-import { useState, useEffect } from "react";
 import { motion } from "framer-motion";
 import { fadeInUp, staggerChildren } from "@/lib/motion-variants";
 import { Card, CardContent } from "@/components/ui/card";
 import { Shield, Calendar, Mail, MapPin, Globe } from "lucide-react";
 
 export default function PrivacyPage() {
-  const [language, setLanguage] = useState<"en" | "ar">("en");
-
-  useEffect(() => {
-    const savedLang = localStorage.getItem("language") as "en" | "ar";
-    if (savedLang) {
-      setLanguage(savedLang);
-      document.documentElement.dir = savedLang === "ar" ? "rtl" : "ltr";
-    }
-  }, []);
-
   const lastUpdated = new Date().toLocaleDateString('en-US', {
     year: 'numeric',
     month: 'long',

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,22 +1,11 @@
 "use client";
 
-import { useState, useEffect } from "react";
 import { motion } from "framer-motion";
 import { fadeInUp, staggerChildren } from "@/lib/motion-variants";
 import { Card, CardContent } from "@/components/ui/card";
 import { FileText, Calendar, Mail, Scale } from "lucide-react";
 
 export default function TermsPage() {
-  const [language, setLanguage] = useState<"en" | "ar">("en");
-
-  useEffect(() => {
-    const savedLang = localStorage.getItem("language") as "en" | "ar";
-    if (savedLang) {
-      setLanguage(savedLang);
-      document.documentElement.dir = savedLang === "ar" ? "rtl" : "ltr";
-    }
-  }, []);
-
   const lastUpdated = "4 October 2025";
 
   return (

--- a/app/use-cases/events/page.tsx
+++ b/app/use-cases/events/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState, useEffect } from "react";
 import { motion } from "framer-motion";
 import { fadeInUp, staggerChildren } from "@/lib/motion-variants";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -23,18 +22,7 @@ import {
 import { Breadcrumbs } from "@/components/shared/breadcrumbs";
 
 export default function EventsPage() {
-  const [language, setLanguage] = useState<"en" | "ar">("en");
-
-  useEffect(() => {
-    const savedLang = localStorage.getItem("language") as "en" | "ar";
-    if (savedLang) {
-      setLanguage(savedLang);
-      document.documentElement.dir = savedLang === "ar" ? "rtl" : "ltr";
-    }
-  }, []);
-
   const content = {
-    en: {
       hero: {
         badge: "Event Management",
         title: "AI-Powered Security for",
@@ -127,104 +115,9 @@ export default function EventsPage() {
         description: "See how Triya.ai can transform your event security and analytics",
         primaryButton: "Request Demo",
       }
-    },
-    ar: {
-      hero: {
-        badge: "إدارة الفعاليات",
-        title: "الأمن المدعوم بالذكاء الاصطناعي",
-        titleHighlight: "للأحداث الكبرى",
-        subtitle: "ضمان سلامة الحضور وتحسين تدفق الحشود وتعزيز تجارب الأحداث بالمراقبة الذكية."
-      },
-      caseStudy: {
-        badge: "دراسة حالة",
-        title: "اصنع في الإمارات 2025",
-        subtitle: "معرض أبوظبي الرائد للتصنيع والتكنولوجيا",
-        stats: [
-          { value: "20%", label: "تقليل وقت الانتظار" },
-          { value: "صفر", label: "تأخير كبار الشخصيات" },
-          { value: "30%", label: "زيادة رؤية الرعاة" },
-          { value: "300+", label: "حماية كبار الشخصيات" }
-        ],
-        challenges: {
-          title: "تحديات الحدث",
-          items: [
-            "إدارة أكثر من 10,000 حاضر عبر قاعات عرض متعددة",
-            "ضمان حركة سلسة لكبار الشخصيات عبر ممرات مخصصة",
-            "تحسين تدفق الزوار لزيادة مشاركة الرعاة",
-            "مراقبة كثافة الحشود في الوقت الفعلي للسلامة"
-          ]
-        },
-        solution: {
-          title: "حل Triya.ai",
-          items: [
-            {
-              title: "تحليلات الطوابير في الوقت الفعلي",
-              description: "مراقبة نقاط الدخول ومكاتب التسجيل، مما قلل أوقات الانتظار بنسبة 20% من خلال التخصيص الديناميكي للموظفين"
-            },
-            {
-              title: "حماية ممر كبار الشخصيات",
-              description: "ضمان عدم التأخير لأكثر من 300 ضيف من كبار الشخصيات مع مراقبة المسار المخصص والتنبيهات الفورية"
-            },
-            {
-              title: "تحسين التدفق الاستراتيجي",
-              description: "زيادة رؤية أكشاك الرعاة بنسبة 30% من خلال توجيه الزوار الذكي"
-            },
-            {
-              title: "تحليلات قابلة للتنفيذ",
-              description: "توفير رؤى في الوقت الفعلي تمكن من إعادة توازن حركة المرور بنسبة 5-10% طوال الحدث"
-            }
-          ]
-        }
-      },
-      features: {
-        title: "ميزات أمن الأحداث",
-        items: [
-          {
-            icon: Users,
-            title: "مراقبة كثافة الحشود",
-            description: "تحليل في الوقت الفعلي لكثافة الحشود لمنع المواقف الخطرة",
-            stats: "تنبيهات بالذكاء الاصطناعي"
-          },
-          {
-            icon: Shield,
-            title: "حماية كبار الشخصيات",
-            description: "مراقبة مخصصة لمناطق كبار الشخصيات وممرات الحركة",
-            stats: "صفر حوادث"
-          },
-          {
-            icon: Clock,
-            title: "إدارة الطوابير",
-            description: "مراقبة وتحسين نقاط الدخول والتسجيل والمناطق الرئيسية",
-            stats: "دخول أسرع 50%"
-          },
-          {
-            icon: BarChart3,
-            title: "تحليلات الأحداث",
-            description: "رؤى شاملة حول تدفق الحضور والمشاركة",
-            stats: "لوحة معلومات فورية"
-          }
-        ]
-      },
-      benefits: {
-        title: "لماذا تختار Triya.ai للأحداث",
-        items: [
-          "ضمان سلامة الحضور مع مراقبة الحشود في الوقت الفعلي",
-          "تحسين تدفق الزوار وتقليل الازدحام",
-          "حماية كبار الشخصيات بمراقبة مخصصة",
-          "زيادة عائد استثمار الرعاة من خلال رؤى التوضع الاستراتيجي",
-          "دعم كامل باللغتين العربية والإنجليزية",
-          "المعالجة المحلية تضمن خصوصية البيانات"
-        ]
-      },
-      cta: {
-        title: "أمّن حدثك القادم",
-        description: "اكتشف كيف يمكن لـ Triya.ai تحويل أمن وتحليلات حدثك",
-        primaryButton: "طلب عرض توضيحي",
-      }
-    }
   };
 
-  const t = content[language];
+  const t = content;
 
   return (
     <>

--- a/app/use-cases/manufacturing/page.tsx
+++ b/app/use-cases/manufacturing/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState, useEffect } from "react";
 import { motion } from "framer-motion";
 import { fadeInUp, staggerChildren } from "@/lib/motion-variants";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -21,18 +20,7 @@ import Link from "next/link";
 import { Breadcrumbs } from "@/components/shared/breadcrumbs";
 
 export default function ManufacturingPage() {
-  const [language, setLanguage] = useState<"en" | "ar">("en");
-
-  useEffect(() => {
-    const savedLang = localStorage.getItem("language") as "en" | "ar";
-    if (savedLang) {
-      setLanguage(savedLang);
-      document.documentElement.dir = savedLang === "ar" ? "rtl" : "ltr";
-    }
-  }, []);
-
   const content = {
-    en: {
       hero: {
         badge: "Manufacturing",
         title: "AI-Powered Safety and Security for",
@@ -106,85 +94,9 @@ export default function ManufacturingPage() {
         description: "See how Triya.ai can enhance safety and productivity in your facility",
         primaryButton: "Request Demo",
       }
-    },
-    ar: {
-      hero: {
-        badge: "التصنيع",
-        title: "الأمن والسلامة المدعومة بالذكاء الاصطناعي",
-        titleHighlight: "لمرافق التصنيع",
-        subtitle: "ضمان سلامة العمال، ومنع سرقة المعدات، وتحسين الإنتاج باستخدام مراقبة الذكاء الاصطناعي الطرفي المصممة للبيئات الصناعية."
-      },
-      challenges: {
-        title: "تحديات أمن التصنيع",
-        items: [
-          {
-            icon: HardHat,
-            title: "الامتثال لمعدات الحماية الشخصية",
-            description: "المراقبة اليدوية للامتثال لمعدات السلامة غير فعالة وعرضة للخطأ"
-          },
-          {
-            icon: AlertTriangle,
-            title: "حوادث مكان العمل",
-            description: "التأخر في الاستجابة لحوادث السلامة يمكن أن يؤدي إلى إصابات خطيرة"
-          },
-          {
-            icon: Shield,
-            title: "سرقة المعدات",
-            description: "الآلات والمواد عالية القيمة معرضة للسرقة"
-          },
-          {
-            icon: BarChart3,
-            title: "تتبع الإنتاجية",
-            description: "رؤية محدودة لكفاءة خط الإنتاج والاختناقات"
-          }
-        ]
-      },
-      solution: {
-        title: "حل Triya.ai للتصنيع",
-        description: "تحول منصة الذكاء الاصطناعي الطرفي الخاصة بنا كاميرات الأمان الموجودة لديك إلى أجهزة مراقبة ذكية للسلامة والإنتاجية.",
-        features: [
-          {
-            title: "كشف معدات الحماية الشخصية في الوقت الفعلي",
-            description: "اكتشف على الفور الخوذات المفقودة وسترات الأمان والقفازات وغيرها من معدات الحماية",
-            stats: "دقة 99%"
-          },
-          {
-            title: "مراقبة منطقة الخطر",
-            description: "التنبيه عندما يدخل العمال مناطق محظورة أو خطرة دون إذن مناسب",
-            stats: "استجابة <500ms"
-          },
-          {
-            title: "أمن المعدات",
-            description: "تتبع استخدام الآلات واكتشاف الوصول أو الحركة غير المصرح بها",
-            stats: "مراقبة 24/7"
-          },
-          {
-            title: "تحليلات الإنتاج",
-            description: "مراقبة كفاءة سير العمل وتحديد الاختناقات في الوقت الفعلي",
-            stats: "زيادة الكفاءة 30%"
-          }
-        ]
-      },
-      benefits: {
-        title: "الفوائد الرئيسية",
-        items: [
-          "تقليل حوادث مكان العمل بنسبة تصل إلى 60%",
-          "ضمان الامتثال لمعدات الحماية الشخصية بنسبة 100% تلقائيًا",
-          "منع سرقة المعدات وسوء الاستخدام",
-          "زيادة كفاءة الإنتاج بنسبة 30%",
-          "السيادة الكاملة على البيانات مع المعالجة المحلية",
-          "دعم اللغتين العربية والإنجليزية"
-        ]
-      },
-      cta: {
-        title: "حوّل أمن التصنيع الخاص بك",
-        description: "اكتشف كيف يمكن لـ Triya.ai تعزيز السلامة والإنتاجية في منشأتك",
-        primaryButton: "طلب عرض توضيحي",
-      }
-    }
   };
 
-  const t = content[language];
+  const t = content;
 
   return (
     <>

--- a/app/use-cases/retail/page.tsx
+++ b/app/use-cases/retail/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState, useEffect } from "react";
 import { motion } from "framer-motion";
 import { fadeInUp, staggerChildren } from "@/lib/motion-variants";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -12,25 +11,12 @@ import {
   Users, 
   TrendingUp, 
   ShieldAlert,
-  Eye,
-  BarChart3,
   ArrowRight,
   CheckCircle2,
   Clock
 } from "lucide-react";
 export default function RetailPage() {
-  const [language, setLanguage] = useState<"en" | "ar">("en");
-
-  useEffect(() => {
-    const savedLang = localStorage.getItem("language") as "en" | "ar";
-    if (savedLang) {
-      setLanguage(savedLang);
-      document.documentElement.dir = savedLang === "ar" ? "rtl" : "ltr";
-    }
-  }, []);
-
   const content = {
-    en: {
       hero: {
         badge: "Retail",
         title: "Intelligent Security and Analytics for",
@@ -104,85 +90,9 @@ export default function RetailPage() {
         description: "Discover how AI can protect your assets and enhance customer experience",
         primaryButton: "Schedule Demo",
       }
-    },
-    ar: {
-      hero: {
-        badge: "التجزئة",
-        title: "الأمن والتحليلات الذكية",
-        titleHighlight: "لبيئات التجزئة",
-        subtitle: "منع الخسائر وتعزيز تجربة العملاء وتحسين العمليات باستخدام المراقبة المدعومة بالذكاء الاصطناعي المصممة للتجزئة الحديثة."
-      },
-      challenges: {
-        title: "تحديات أمن وعمليات التجزئة",
-        items: [
-          {
-            icon: ShieldAlert,
-            title: "السرقة من المتاجر",
-            description: "تكلف الخسائر السنوية تجار التجزئة المليارات مع عدم قدرة الأمن التقليدي على منع الخسائر"
-          },
-          {
-            icon: Users,
-            title: "تجربة العملاء",
-            description: "الطوابير الطويلة والخدمة السيئة تؤدي إلى عدم رضا العملاء وخسارة المبيعات"
-          },
-          {
-            icon: TrendingUp,
-            title: "تحليلات المتجر",
-            description: "رؤى محدودة حول سلوك العملاء وأداء المتجر"
-          },
-          {
-            icon: Clock,
-            title: "الاستجابة للحوادث",
-            description: "التأخر في اكتشاف الحوادث الأمنية والاستجابة لها"
-          }
-        ]
-      },
-      solution: {
-        title: "حل Triya.ai للتجزئة",
-        description: "حوّل كاميرات متجرك إلى أدوات أعمال ذكية تحمي الأصول وتزيد الإيرادات.",
-        features: [
-          {
-            title: "كشف السرقة في الوقت الفعلي",
-            description: "تحديد السلوك المشبوه وتنبيه الموظفين على الفور لمنع الخسائر",
-            stats: "تقليل الخسائر 70%"
-          },
-          {
-            title: "إدارة الطوابير",
-            description: "مراقبة خطوط الدفع وتنبيه الموظفين عند الحاجة إلى سجلات إضافية",
-            stats: "دفع أسرع 40%"
-          },
-          {
-            title: "تحليلات العملاء",
-            description: "تتبع حركة المرور ووقت البقاء وأنماط التسوق لتحسين التصميم",
-            stats: "زيادة المبيعات 25%"
-          },
-          {
-            title: "خرائط الحرارة",
-            description: "تصور أنماط حركة العملاء لتحسين وضع المنتج",
-            stats: "رؤى في الوقت الفعلي"
-          }
-        ]
-      },
-      benefits: {
-        title: "الفوائد الرئيسية",
-        items: [
-          "تقليل الانكماش بنسبة تصل إلى 70%",
-          "تحسين درجات رضا العملاء بنسبة 35%",
-          "زيادة تحويل المبيعات بنسبة 25%",
-          "تحسين تخصيص الموظفين في الوقت الفعلي",
-          "الامتثال الكامل لـ GDPR/PDPL",
-          "رؤى العملاء باللغتين العربية والإنجليزية"
-        ]
-},
-      cta: {
-        title: "ثورة في أمن التجزئة الخاص بك",
-        description: "اكتشف كيف يمكن للذكاء الاصطناعي حماية أصولك وتعزيز تجربة العملاء",
-        primaryButton: "جدولة عرض توضيحي",
-      }
-    }
   };
 
-  const t = content[language];
+  const t = content;
 
   return (
     <>

--- a/app/use-cases/smart-cities/page.tsx
+++ b/app/use-cases/smart-cities/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState, useEffect } from "react";
 import { motion } from "framer-motion";
 import { fadeInUp, staggerChildren } from "@/lib/motion-variants";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -21,18 +20,7 @@ import {
 import { Breadcrumbs } from "@/components/shared/breadcrumbs";
 
 export default function SmartCitiesPage() {
-  const [language, setLanguage] = useState<"en" | "ar">("en");
-
-  useEffect(() => {
-    const savedLang = localStorage.getItem("language") as "en" | "ar";
-    if (savedLang) {
-      setLanguage(savedLang);
-      document.documentElement.dir = savedLang === "ar" ? "rtl" : "ltr";
-    }
-  }, []);
-
   const content = {
-    en: {
       hero: {
         badge: "Smart Cities",
         title: "Intelligent Urban Surveillance for",
@@ -106,85 +94,9 @@ export default function SmartCitiesPage() {
         description: "Discover how AI can make your city safer and more efficient",
         primaryButton: "Request Demo",
       }
-    },
-    ar: {
-      hero: {
-        badge: "المدن الذكية",
-        title: "المراقبة الحضرية الذكية",
-        titleHighlight: "لمدن أكثر أماناً",
-        subtitle: "حوّل البنية التحتية الحضرية بمراقبة مدعومة بالذكاء الاصطناعي لإدارة حركة المرور والسلامة العامة وتحليلات المدينة."
-      },
-      challenges: {
-        title: "تحديات الأمن والإدارة الحضرية",
-        items: [
-          {
-            icon: Car,
-            title: "ازدحام المرور",
-            description: "إدارة تدفق حركة المرور واكتشاف الحوادث في الوقت الفعلي عبر شوارع المدينة"
-          },
-          {
-            icon: Users,
-            title: "السيطرة على الحشود",
-            description: "مراقبة التجمعات الكبيرة ومنع كثافة الحشود الخطرة"
-          },
-          {
-            icon: AlertTriangle,
-            title: "الاستجابة للحوادث",
-            description: "التأخر في اكتشاف الحوادث أو الجرائم أو حالات الطوارئ والاستجابة لها"
-          },
-          {
-            icon: Map,
-            title: "التخطيط الحضري",
-            description: "بيانات محدودة عن أنماط المشاة والمركبات للتخطيط الحضري"
-          }
-        ]
-      },
-      solution: {
-        title: "حل Triya.ai للمدن الذكية",
-        description: "أنشئ مدناً أكثر أماناً وكفاءة مع مراقبة وتحليلات الذكاء الاصطناعي الطرفي.",
-        features: [
-          {
-            title: "تحسين تدفق حركة المرور",
-            description: "مراقبة أنماط حركة المرور واكتشاف الازدحام أو الحوادث أو المخالفات في الوقت الفعلي",
-            stats: "ازدحام أقل 30%"
-          },
-          {
-            title: "مراقبة السلامة العامة",
-            description: "اكتشاف السلوك المشبوه والأشياء المتروكة والتهديدات الأمنية تلقائياً",
-            stats: "استجابة أسرع 50%"
-          },
-          {
-            title: "تحليلات الحشود",
-            description: "مراقبة كثافة الحشود وأنماط الحركة لمنع التدافع وتحسين التدفق",
-            stats: "تنبيهات فورية"
-          },
-          {
-            title: "لوحة تحليلات حضرية",
-            description: "رؤى شاملة على مستوى المدينة لتحسين التخطيط وتخصيص الموارد",
-            stats: "قرارات مبنية على البيانات"
-          }
-        ]
-      },
-      benefits: {
-        title: "الفوائد الرئيسية",
-        items: [
-          "تقليل ازدحام المرور بنسبة 30%",
-          "تحسين وقت الاستجابة للطوارئ بنسبة 50%",
-          "منع الحوادث المتعلقة بالحشود",
-          "تحسين تخصيص موارد المدينة",
-          "السيادة الكاملة على بيانات المواطنين",
-          "واجهة مركز القيادة باللغتين العربية والإنجليزية"
-        ]
-      },
-      cta: {
-        title: "ابنِ البنية التحتية لمدينتك الذكية",
-        description: "اكتشف كيف يمكن للذكاء الاصطناعي جعل مدينتك أكثر أماناً وكفاءة",
-        primaryButton: "طلب عرض توضيحي",
-      }
-    }
   };
 
-  const t = content[language];
+  const t = content;
 
   return (
     <>

--- a/components/sections/cta-section.tsx
+++ b/components/sections/cta-section.tsx
@@ -4,13 +4,8 @@ import { Button } from "@/components/ui/button";
 import { ArrowRight, Calendar } from "lucide-react";
 import Link from "next/link";
 
-interface CTASectionProps {
-  language: "en" | "ar";
-}
-
-export function CTASection({ language }: CTASectionProps) {
+export function CTASection() {
   const content = {
-    en: {
       title: "Ready to transform your security?",
       subtitle: "Join leading organizations using Triya.ai for intelligent surveillance",
       cta1: "Schedule Demo",
@@ -23,24 +18,9 @@ export function CTASection({ language }: CTASectionProps) {
       stat3Label: "Smart Alerts",
       stat4: "360°",
       stat4Label: "Business Insights"
-    },
-    ar: {
-      title: "مستعد لتحويل أمانك؟",
-      subtitle: "انضم إلى المؤسسات الرائدة التي تستخدم Triya.ai للمراقبة الذكية",
-      cta1: "جدولة عرض توضيحي",
-      cta2: "اتصل بالمبيعات",
-      stat1: "85%",
-      stat1Label: "تخفيض التكلفة",
-      stat2: "24/7",
-      stat2Label: "مراقبة وكلاء الذكاء الاصطناعي",
-      stat3: "فوري",
-      stat3Label: "تنبيهات ذكية",
-      stat4: "360°",
-      stat4Label: "رؤى الأعمال"
-    }
   };
 
-  const t = content[language];
+  const t = content;
 
   return (
     <section className="relative py-24 overflow-hidden">

--- a/components/sections/how-it-works.tsx
+++ b/components/sections/how-it-works.tsx
@@ -4,13 +4,8 @@ import { Card } from "@/components/ui/card";
 import Image from "next/image";
 import { Camera, Cpu, Brain, Monitor } from "lucide-react";
 
-interface HowItWorksProps {
-  language: "en" | "ar";
-}
-
-export function HowItWorks({ language }: HowItWorksProps) {
+export function HowItWorks() {
   const content = {
-    en: {
       title: "How It Works",
       subtitle: "Triya AI turns any CCTV camera into an on-prem, natural language conversation system, security & insight engine",
       steps: [
@@ -39,40 +34,9 @@ export function HowItWorks({ language }: HowItWorksProps) {
           number: "04"
         }
       ]
-    },
-    ar: {
-      title: "كيف يعمل",
-      subtitle: "Triya AI تحول أي كاميرا CCTV إلى نظام محادثة باللغة الطبيعية محلي، ومحرك أمان ورؤى",
-      steps: [
-        {
-          icon: Camera,
-          title: "تغذية الكاميرا",
-          description: "ربط الكاميرات الموجودة من أي مورد. لا حاجة لاستبدال البنية التحتية الحالية للكاميرات.",
-          number: "01"
-        },
-        {
-          icon: Cpu,
-          title: "صندوق Triya AI الطرفي",
-          description: "نشر صندوق الحوسبة الطرفية في موقعك للمعالجة المحلية مع السيادة الكاملة على البيانات.",
-          number: "02"
-        },
-        {
-          icon: Brain,
-          title: "وكلاء Triya AI",
-          description: "وكلاء ذكاء اصطناعي متقدمون يعالجون موجزات الفيديو مع دعم كامل للغة العربية وقدرات متعددة اللغات.",
-          number: "03"
-        },
-        {
-          icon: Monitor,
-          title: "استخدام TriyaAI",
-          description: "التكامل السلس مع مركز القيادة الموجود لديك للمراقبة والرؤى في الوقت الفعلي.",
-          number: "04"
-        }
-      ]
-    }
   };
 
-  const t = content[language];
+  const t = content;
 
   return (
     <section className="py-24 bg-muted/30">

--- a/components/sections/product-showcase.tsx
+++ b/components/sections/product-showcase.tsx
@@ -12,13 +12,8 @@ import {
 import { motion } from "framer-motion";
 import { fadeInUp, staggerChildren } from "@/lib/motion-variants";
 
-interface ProductShowcaseProps {
-  language: "en" | "ar";
-}
-
-export function ProductShowcase({ language }: ProductShowcaseProps) {
+export function ProductShowcase() {
   const content = {
-    en: {
       title: "Our Features",
       subtitle: "Cutting-edge technology designed for modern surveillance needs",
       features: [
@@ -59,52 +54,9 @@ export function ProductShowcase({ language }: ProductShowcaseProps) {
           badge: "Versatile"
         }
       ]
-    },
-    ar: {
-      title: "ميزاتنا",
-      subtitle: "تقنية متطورة مصممة لاحتياجات المراقبة الحديثة",
-      features: [
-        {
-          icon: DollarSign,
-          title: "توفير 85% من التكاليف",
-          description: "تحديث الكاميرات الموجودة؛ أرخص بكثير من الاستبدال",
-          badge: "فعال من حيث التكلفة"
-        },
-        {
-          icon: Shield,
-          title: "الذكاء الاصطناعي السيادي",
-          description: "الاستدلال الطرفي، عدم الاعتماد على السحابة، التحكم في البيانات المحلية",
-          badge: "آمن"
-        },
-        {
-          icon: Search,
-          title: "تحقيقات أسرع بنسبة 90%",
-          description: "تحدث مع الذكاء الاصطناعي بلغتك (أكثر من 30 لغة مدعومة) لتحقيقات أسرع",
-          badge: "فعال"
-        },
-        {
-          icon: Unlock,
-          title: "لا قيود من الموردين",
-          description: "متوافق مع جميع الكاميرات، يعمل مع أي كاميرات IP موجودة",
-          badge: "مرن"
-        },
-        {
-          icon: LineChart,
-          title: "تحليلات متقدمة",
-          description: "لوحات معلومات شاملة مع رؤى في الوقت الفعلي وتحليل تاريخي",
-          badge: "قائم على البيانات"
-        },
-        {
-          icon: Shield,
-          title: "دعم متعدد الصناعات",
-          description: "حلول مخصصة للتصنيع والتجزئة والرعاية الصحية والمدن الذكية",
-          badge: "متعدد الاستخدامات"
-        }
-      ]
-    }
   };
 
-  const t = content[language];
+  const t = content;
 
   return (
     <section className="py-24 bg-background">

--- a/components/sections/use-cases.tsx
+++ b/components/sections/use-cases.tsx
@@ -6,13 +6,8 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Button } from "@/components/ui/button";
 import { ArrowRight, Factory, ShoppingCart, Building2, Calendar } from "lucide-react";
 
-interface UseCasesProps {
-  language: "en" | "ar";
-}
-
-export function UseCases({ language }: UseCasesProps) {
+export function UseCases() {
   const content = {
-    en: {
       title: "Industry Solutions",
       subtitle: "Tailored AI surveillance for every sector",
       cta: "Learn More",
@@ -50,49 +45,9 @@ export function UseCases({ language }: UseCasesProps) {
           image: "/images/industries/events_1.png"
         }
       ]
-    },
-    ar: {
-      title: "حلول الصناعة",
-      subtitle: "مراقبة بالذكاء الاصطناعي مخصصة لكل قطاع",
-      cta: "اعرف المزيد",
-      industries: [
-        {
-          icon: Factory,
-          slug: "manufacturing",
-          title: "التصنيع",
-          description: "راقب خطوط الإنتاج، وتأكد من سلامة العمال، وامنع سرقة المعدات بمراقبة على مدار الساعة.",
-          features: ["مراقبة الامتثال للسلامة", "منع السرقة", "مراقبة الجودة", "إنتاجية العمال"],
-          image: "/images/industries/manufacturing_1.png"
-        },
-        {
-          icon: ShoppingCart,
-          slug: "retail",
-          title: "التجزئة",
-          description: "حسّن تجربة العملاء، وامنع السرقة، وحسّن عمليات المتجر بالمراقبة الذكية.",
-          features: ["منع الخسائر", "تحليلات العملاء", "إدارة الطوابير", "خرائط الحرارة"],
-          image: "/images/industries/retail_1.png"
-        },
-        {
-          icon: Building2,
-          slug: "smart-cities",
-          title: "المدن الذكية",
-          description: "أنشئ بيئات حضرية أكثر أماناً مع مراقبة حركة المرور وإدارة الحشود وكشف الحوادث.",
-          features: ["تحليل المرور", "السيطرة على الحشود", "الاستجابة للحوادث", "السلامة العامة"],
-          image: "/images/industries/smart-cities_1.png"
-        },
-        {
-          icon: Calendar,
-          slug: "events",
-          title: "إدارة الفعاليات",
-          description: "ضمان سلامة الحضور وتحسين تدفق الحشود وتعزيز تجارب الأحداث بالمراقبة الذكية.",
-          features: ["تحليلات الطوابير الفورية", "حماية ممر كبار الشخصيات", "تحسين التدفق الاستراتيجي", "تحليلات قابلة للتنفيذ"],
-          image: "/images/industries/events_1.png"
-        }
-      ]
-    }
   };
 
-  const t = content[language];
+  const t = content;
 
   return (
     <section className="py-24 bg-muted/50">

--- a/components/shared/breadcrumbs.tsx
+++ b/components/shared/breadcrumbs.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import Link from "next/link";
-import { ChevronRight, ChevronLeft, Home } from "lucide-react";
+import { ChevronRight, Home } from "lucide-react";
 import { usePathname } from "next/navigation";
-import { useState, useEffect } from "react";
 
 interface BreadcrumbItem {
   label: string;
@@ -12,41 +11,20 @@ interface BreadcrumbItem {
 
 export function Breadcrumbs() {
   const pathname = usePathname();
-  const [language, setLanguage] = useState<"en" | "ar">("en");
 
-  useEffect(() => {
-    const savedLang = localStorage.getItem("language") as "en" | "ar";
-    if (savedLang) {
-      setLanguage(savedLang);
-    }
-  }, []);
-  
   // Translations
   const translations = {
-    en: {
-      home: "Home",
-      blog: "Blog",
-      faq: "FAQ",
-      contact: "Contact",
-      "use-cases": "Use Cases",
-      "smart-cities": "Smart Cities",
-      about: "About",
-      pricing: "Pricing"
-    },
-    ar: {
-      home: "الرئيسية",
-      blog: "المدونة",
-      faq: "الأسئلة الشائعة",
-      contact: "اتصل بنا",
-      "use-cases": "حالات الاستخدام",
-      "smart-cities": "المدن الذكية",
-      about: "من نحن",
-      pricing: "الأسعار"
-    }
+    home: "Home",
+    blog: "Blog",
+    faq: "FAQ",
+    contact: "Contact",
+    "use-cases": "Use Cases",
+    "smart-cities": "Smart Cities",
+    about: "About",
+    pricing: "Pricing"
   };
 
-  // Select appropriate chevron icon based on language
-  const ChevronIcon = language === "ar" ? ChevronLeft : ChevronRight;
+  const ChevronIcon = ChevronRight;
   
   // Don't show breadcrumbs on homepage
   if (pathname === "/" || pathname === "") return null;
@@ -57,7 +35,7 @@ export function Breadcrumbs() {
   // Generate breadcrumb items from pathname
   const generateBreadcrumbs = (): BreadcrumbItem[] => {
     const items: BreadcrumbItem[] = [
-      { label: translations[language].home, href: "/" }
+      { label: translations.home, href: "/" }
     ];
     
     const segments = pathname.split("/").filter(Boolean);
@@ -67,7 +45,7 @@ export function Breadcrumbs() {
       currentPath += `/${segment}`;
       
       // Try to get translation first
-      let label = translations[language][segment as keyof typeof translations.en] || 
+      let label = translations[segment as keyof typeof translations] ||
         // If no translation, format the label (capitalize, replace hyphens)
         segment
           .split("-")
@@ -106,7 +84,7 @@ export function Breadcrumbs() {
       
       <nav aria-label="Breadcrumb" className="py-3 px-4 sm:px-6 bg-muted/30">
         <div className="container mx-auto">
-          <ol className={`flex items-center text-sm ${language === "ar" ? "gap-2" : "space-x-2"}`}>
+          <ol className="flex items-center text-sm space-x-2">
             {breadcrumbs.map((item, index) => (
               <li key={item.href} className="flex items-center">
                 {index > 0 && (
@@ -116,7 +94,7 @@ export function Breadcrumbs() {
                 {index === breadcrumbs.length - 1 ? (
                   // Current page (not clickable)
                   <span className="text-foreground font-medium">
-                    {index === 0 && <Home className={`h-4 w-4 inline ${language === "ar" ? "ml-1" : "mr-1"}`} />}
+                    {index === 0 && <Home className="h-4 w-4 inline mr-1" />}
                     {item.label}
                   </span>
                 ) : (
@@ -125,7 +103,7 @@ export function Breadcrumbs() {
                     href={item.href}
                     className="text-muted-foreground hover:text-primary transition-colors"
                   >
-                    {index === 0 && <Home className={`h-4 w-4 inline ${language === "ar" ? "ml-1" : "mr-1"}`} />}
+                    {index === 0 && <Home className="h-4 w-4 inline mr-1" />}
                     {item.label}
                   </Link>
                 )}

--- a/components/shared/footer/index.tsx
+++ b/components/shared/footer/index.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState, useEffect } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { Button } from "@/components/ui/button";
@@ -8,65 +7,33 @@ import { Card } from "@/components/ui/card";
 import { MapPin, Mail, Phone, Linkedin } from "lucide-react";
 import { useAnalytics } from "@/hooks/useAnalytics";
 
-const getContent = (language: "en" | "ar") => ({
-  en: {
-    description: "Transform any camera into a privacy-first, AI-powered security & analytics solution",
-    industries: "Industries",
-    industryItems: [
-      { title: "Manufacturing", href: "/use-cases/manufacturing/" },
-      { title: "Retail", href: "/use-cases/retail/" },
-      { title: "Event Management", href: "/use-cases/events/" },
-      { title: "Smart Cities", href: "/use-cases/smart-cities/" },
-    ],
-    resources: "Resources",
-    resourceItems: [
-      { title: "Blog", href: "/blog/" },
-      { title: "FAQ", href: "/faq/" },
-      { title: "Contact", href: "/contact/" },
-    ],
-    contactUs: "Contact Us",
-    headquarters: "Headquarters",
-    headquartersLocation: "Sky Tower, Al Reem Island, Abu Dhabi, UAE",
-    copyright: "© 2025 Triya.ai. All rights reserved.",
-    privacyPolicy: "Privacy Policy",
-    termsOfService: "Terms of Service"
-  },
-  ar: {
-    description: "حوّل أي كاميرا إلى حل أمني وتحليلي مدعوم بالذكاء الاصطناعي ويحمي الخصوصية",
-    industries: "الصناعات",
-    industryItems: [
-      { title: "التصنيع", href: "/use-cases/manufacturing/" },
-      { title: "التجزئة", href: "/use-cases/retail/" },
-      { title: "إدارة الفعاليات", href: "/use-cases/events/" },
-      { title: "المدن الذكية", href: "/use-cases/smart-cities/" },
-    ],
-    resources: "الموارد",
-    resourceItems: [
-      { title: "المدونة", href: "/blog/" },
-      { title: "الأسئلة الشائعة", href: "/faq/" },
-      { title: "اتصل بنا", href: "/contact/" },
-    ],
-    contactUs: "اتصل بنا",
-    headquarters: "المقر الرئيسي",
-    headquartersLocation: "سكاي تاور، جزيرة الريم، أبوظبي، الإمارات",
-    copyright: "© 2025 Triya.ai. جميع الحقوق محفوظة.",
-    privacyPolicy: "سياسة الخصوصية",
-    termsOfService: "شروط الخدمة"
-  }
-}[language]);
+const content = {
+  description: "Transform any camera into a privacy-first, AI-powered security & analytics solution",
+  industries: "Industries",
+  industryItems: [
+    { title: "Manufacturing", href: "/use-cases/manufacturing/" },
+    { title: "Retail", href: "/use-cases/retail/" },
+    { title: "Event Management", href: "/use-cases/events/" },
+    { title: "Smart Cities", href: "/use-cases/smart-cities/" },
+  ],
+  resources: "Resources",
+  resourceItems: [
+    { title: "Blog", href: "/blog/" },
+    { title: "FAQ", href: "/faq/" },
+    { title: "Contact", href: "/contact/" },
+  ],
+  contactUs: "Contact Us",
+  headquarters: "Headquarters",
+  headquartersLocation: "Sky Tower, Al Reem Island, Abu Dhabi, UAE",
+  copyright: "© 2025 Triya.ai. All rights reserved.",
+  privacyPolicy: "Privacy Policy",
+  termsOfService: "Terms of Service"
+};
 
 export function Footer() {
-  const [language, setLanguage] = useState<"en" | "ar">("en");
   const { trackLinkedInClick } = useAnalytics();
-  
-  useEffect(() => {
-    const savedLang = localStorage.getItem("language") as "en" | "ar";
-    if (savedLang) {
-      setLanguage(savedLang);
-    }
-  }, []);
-  
-  const t = getContent(language);
+
+  const t = content;
   
   return (
     <footer className="border-t bg-muted/50">

--- a/components/shared/navbar/index.tsx
+++ b/components/shared/navbar/index.tsx
@@ -17,89 +17,40 @@ import { cn } from "@/lib/utils";
 import React from "react";
 import { MobileNav } from "./mobile-nav";
 
-const getContent = (language: "en" | "ar") => ({
-  en: {
-    industries: "Industries",
-    blog: "Blog",
-    faq: "FAQ",
-    contact: "Contact",
-    requestDemo: "Request Demo",
-    industryItems: [
-      {
-        title: "Manufacturing",
-        href: "/use-cases/manufacturing/",
-        description: "PPE compliance and safety monitoring for industrial facilities",
-      },
-      {
-        title: "Retail",
-        href: "/use-cases/retail/",
-        description: "Theft prevention and customer analytics for stores",
-      },
-      {
-        title: "Smart Cities",
-        href: "/use-cases/smart-cities/",
-        description: "Traffic management and public safety solutions",
-      },
-      {
-        title: "Event Management",
-        href: "/use-cases/events/",
-        description: "Crowd analytics and security for major events",
-      },
-    ]
-  },
-  ar: {
-    industries: "الصناعات",
-    blog: "المدونة",
-    faq: "الأسئلة الشائعة",
-    contact: "اتصل بنا",
-    requestDemo: "طلب عرض توضيحي",
-    industryItems: [
-      {
-        title: "التصنيع",
-        href: "/use-cases/manufacturing/",
-        description: "الامتثال لمعدات الحماية الشخصية ومراقبة السلامة للمرافق الصناعية",
-      },
-      {
-        title: "التجزئة",
-        href: "/use-cases/retail/",
-        description: "منع السرقة وتحليلات العملاء للمتاجر",
-      },
-      {
-        title: "المدن الذكية",
-        href: "/use-cases/smart-cities/",
-        description: "إدارة حركة المرور وحلول السلامة العامة",
-      },
-      {
-        title: "إدارة الفعاليات",
-        href: "/use-cases/events/",
-        description: "تحليلات الحشود والأمن للأحداث الكبرى",
-      },
-    ]
-  }
-}[language]);
+const content = {
+  industries: "Industries",
+  blog: "Blog",
+  faq: "FAQ",
+  contact: "Contact",
+  requestDemo: "Request Demo",
+  industryItems: [
+    {
+      title: "Manufacturing",
+      href: "/use-cases/manufacturing/",
+      description: "PPE compliance and safety monitoring for industrial facilities",
+    },
+    {
+      title: "Retail",
+      href: "/use-cases/retail/",
+      description: "Theft prevention and customer analytics for stores",
+    },
+    {
+      title: "Smart Cities",
+      href: "/use-cases/smart-cities/",
+      description: "Traffic management and public safety solutions",
+    },
+    {
+      title: "Event Management",
+      href: "/use-cases/events/",
+      description: "Crowd analytics and security for major events",
+    },
+  ]
+};
 
 export function Navbar() {
-  const [language, setLanguage] = React.useState<"en" | "ar">("en");
   const { trackRequestDemo } = useAnalytics();
 
-  React.useEffect(() => {
-    // Check for saved language preference
-    const savedLang = localStorage.getItem("language") as "en" | "ar";
-    if (savedLang) {
-      setLanguage(savedLang);
-    }
-  }, []);
-
-  const toggleLanguage = () => {
-    const newLang = language === "en" ? "ar" : "en";
-    setLanguage(newLang);
-    localStorage.setItem("language", newLang);
-    document.documentElement.dir = newLang === "ar" ? "rtl" : "ltr";
-    // Reload page to apply language changes
-    window.location.reload();
-  };
-
-  const t = getContent(language);
+  const t = content;
 
   return (
     <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
@@ -196,9 +147,6 @@ export function Navbar() {
         
         <div className="ml-auto flex items-center space-x-4">
           <div className="hidden md:flex items-center space-x-4">
-            <Button variant="outline" onClick={toggleLanguage}>
-              {language === "en" ? "العربية" : "English"}
-            </Button>
             <Button asChild onClick={() => trackRequestDemo('Navbar')}>
               <Link href="/contact/">{t.requestDemo}</Link>
             </Button>

--- a/components/shared/navbar/mobile-nav.tsx
+++ b/components/shared/navbar/mobile-nav.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Menu, X } from "lucide-react";
@@ -12,71 +12,31 @@ import {
   SheetTrigger,
 } from "@/components/ui/sheet";
 
-const getNavItems = (language: "en" | "ar") => ({
-  en: [
-    {
-      title: "Industries",
-      items: [
-        { title: "Manufacturing", href: "/use-cases/manufacturing/" },
-        { title: "Retail", href: "/use-cases/retail/" },
-        { title: "Smart Cities", href: "/use-cases/smart-cities/" },
-        { title: "Event Management", href: "/use-cases/events/" },
-      ],
-    },
-    { title: "Blog", href: "/blog/" },
-    { title: "FAQ", href: "/faq/" },
-    { title: "Contact", href: "/contact/" },
-  ],
-  ar: [
-    {
-      title: "الصناعات",
-      items: [
-        { title: "التصنيع", href: "/use-cases/manufacturing/" },
-        { title: "التجزئة", href: "/use-cases/retail/" },
-        { title: "المدن الذكية", href: "/use-cases/smart-cities/" },
-        { title: "إدارة الفعاليات", href: "/use-cases/events/" },
-      ],
-    },
-    { title: "المدونة", href: "/blog/" },
-    { title: "الأسئلة الشائعة", href: "/faq/" },
-    { title: "اتصل بنا", href: "/contact/" },
-  ]
-}[language]);
-
-const getContent = (language: "en" | "ar") => ({
-  en: {
-    menu: "Menu",
-    requestDemo: "Request Demo"
+const navItemsData = [
+  {
+    title: "Industries",
+    items: [
+      { title: "Manufacturing", href: "/use-cases/manufacturing/" },
+      { title: "Retail", href: "/use-cases/retail/" },
+      { title: "Smart Cities", href: "/use-cases/smart-cities/" },
+      { title: "Event Management", href: "/use-cases/events/" },
+    ],
   },
-  ar: {
-    menu: "القائمة",
-    requestDemo: "طلب عرض توضيحي"
-  }
-}[language]);
+  { title: "Blog", href: "/blog/" },
+  { title: "FAQ", href: "/faq/" },
+  { title: "Contact", href: "/contact/" },
+];
+
+const content = {
+  menu: "Menu",
+  requestDemo: "Request Demo"
+};
 
 export function MobileNav() {
   const [open, setOpen] = useState(false);
-  const [language, setLanguage] = useState<"en" | "ar">("en");
 
-  useEffect(() => {
-    // Check for saved language preference
-    const savedLang = localStorage.getItem("language") as "en" | "ar";
-    if (savedLang) {
-      setLanguage(savedLang);
-    }
-  }, []);
-
-  const toggleLanguage = () => {
-    const newLang = language === "en" ? "ar" : "en";
-    setLanguage(newLang);
-    localStorage.setItem("language", newLang);
-    document.documentElement.dir = newLang === "ar" ? "rtl" : "ltr";
-    // Reload page to apply language changes
-    window.location.reload();
-  };
-
-  const navItems = getNavItems(language);
-  const t = getContent(language);
+  const navItems = navItemsData;
+  const t = content;
 
   return (
     <Sheet open={open} onOpenChange={setOpen}>
@@ -123,9 +83,6 @@ export function MobileNav() {
             </div>
           ))}
           <div className="pt-4 space-y-2">
-            <Button variant="outline" className="w-full" onClick={toggleLanguage}>
-              {language === "en" ? "العربية" : "English"}
-            </Button>
             <Button className="w-full" asChild>
               <Link href="/contact/">{t.requestDemo}</Link>
             </Button>


### PR DESCRIPTION
## Summary

Removes the bilingual (English/Arabic) UI mechanism across the entire website. The site is now **English-only** — there is no longer any toggle to read the website in Arabic.

## What changed

- **Removed the language toggle** buttons from the desktop navbar and mobile nav.
- **Removed the bilingual content maps** — each component's `getContent(language: "en" | "ar")` (with parallel `en`/`ar` objects) is flattened to the English content directly.
- **Removed all language plumbing**: `language` React state, `localStorage` `"language"` persistence, the reload-on-toggle behavior, and `document.documentElement.dir` RTL switching.
- **Inlined LTR-only choices**: icon direction (Chevron/Arrow) and directional spacing classes now use their English/LTR values.
- **Flattened the FAQ data model** (`app/faq/faq-data.ts`) from `{ en, ar }` fields to plain strings, and updated its consumers/helpers.
- **Blog content** now selects the English field.

**23 files changed, ~341 insertions / ~1,462 deletions.**

## Scope (intentionally left unchanged)

Per the requested scope, this PR removes only the **website's bilingual UI**, not statements about the product:

- English marketing copy referencing the product's Arabic **capabilities** (e.g. "Arabic-first capabilities", "99% Arabic accuracy", "30+ languages including Arabic").
- The `arabic-surveillance-breakthrough` blog article and other blog content.
- The schema.org `"availableLanguage": ["en", "ar"]` in structured data (describes service/support languages, not the UI).

## Verification

- `npm run build` succeeds — all ~30 pages prerender and the static export + sitemap generate cleanly.
- TypeScript type-checking passes.
- Global grep confirms no remaining `language ===`, `[language]`, `toggleLanguage`, `setLanguage`, `localStorage … "language"`, `documentElement.dir`, or `"en" | "ar"` in source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)