### PR TITLE
Fix invalid Product schema (→ Service) + add Asia to areaServed

### DIFF
--- a/app/components/structured-data.tsx
+++ b/app/components/structured-data.tsx
@@ -31,10 +31,16 @@ export function OrganizationSchema() {
     "sameAs": [
       "https://www.linkedin.com/company/triyaai"
     ],
-    "areaServed": {
-      "@type": "Place",
-      "name": "Middle East and North Africa"
-    },
+    "areaServed": [
+      {
+        "@type": "Place",
+        "name": "Middle East and North Africa"
+      },
+      {
+        "@type": "Place",
+        "name": "Asia"
+      }
+    ],
     "knowsAbout": [
       "AI surveillance",
       "Edge computing",
@@ -55,64 +61,72 @@ export function OrganizationSchema() {
   );
 }
 
-export function ProductSchema() {
+export function ServiceSchema() {
   const schema = {
     "@context": "https://schema.org",
-    "@type": "Product",
-    "@id": "https://www.triya.ai/#product",
-    "name": "Triya Edge AI Surveillance Platform",
-    "description": "Revolutionary edge AI surveillance platform with 85% cost savings, on-premise processing, and multi-language support including Arabic",
+    "@type": "Service",
+    "@id": "https://www.triya.ai/#service",
+    "serviceType": "AI Video Analytics & Surveillance Platform",
+    "name": "Triya AI Video Analytics Platform",
+    "description": "AI video analytics platform that turns existing CCTV cameras into a real-time, on-premise threat-detection system with 85% cost savings.",
+    "provider": {
+      "@type": "Organization",
+      "@id": "https://www.triya.ai/#organization",
+      "name": "TRIYA AI LIMITED"
+    },
     "brand": {
       "@type": "Brand",
       "name": "Triya"
     },
-    "manufacturer": {
-      "@type": "Organization",
-      "name": "TRIYA AI LIMITED"
-    },
-    "offers": {
-      "@type": "AggregateOffer",
-      "priceCurrency": "USD",
-      "availability": "https://schema.org/InStock",
-      "offerCount": "4",
-      "offers": [
+    "areaServed": [
+      {
+        "@type": "Place",
+        "name": "Middle East and North Africa"
+      },
+      {
+        "@type": "Place",
+        "name": "Asia"
+      }
+    ],
+    "category": "Enterprise Security Software",
+    "hasOfferCatalog": {
+      "@type": "OfferCatalog",
+      "name": "Triya Solutions",
+      "itemListElement": [
         {
           "@type": "Offer",
-          "name": "Smart City Surveillance",
-          "description": "AI-powered urban security and traffic monitoring"
+          "itemOffered": {
+            "@type": "Service",
+            "name": "Smart City Surveillance",
+            "description": "AI-powered urban security and traffic monitoring"
+          }
         },
         {
           "@type": "Offer",
-          "name": "Retail Security Analytics",
-          "description": "Loss prevention and customer behavior analysis"
+          "itemOffered": {
+            "@type": "Service",
+            "name": "Retail Security Analytics",
+            "description": "Loss prevention and customer behavior analysis"
+          }
         },
         {
           "@type": "Offer",
-          "name": "Manufacturing Safety Monitoring",
-          "description": "PPE compliance and hazard detection"
+          "itemOffered": {
+            "@type": "Service",
+            "name": "Manufacturing Safety Monitoring",
+            "description": "PPE compliance and hazard detection"
+          }
         },
         {
           "@type": "Offer",
-          "name": "Event Security Management",
-          "description": "Crowd control and VIP protection"
+          "itemOffered": {
+            "@type": "Service",
+            "name": "Event Security Management",
+            "description": "Crowd control and VIP protection"
+          }
         }
       ]
-    },
-    "category": "Enterprise Security Software",
-    "isRelatedTo": [
-      {
-        "@type": "Thing",
-        "name": "Artificial Intelligence"
-      },
-      {
-        "@type": "Thing",
-        "name": "Video Surveillance"
-      },
-      {
-        "@type": "Thing",
-        "name": "Edge Computing"
-      }
-    ]
+    }
   };
 
   return (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,7 +8,7 @@ import { useAnalytics } from "@/hooks/useAnalytics";
 import { ProductShowcase } from "@/components/sections/product-showcase";
 import { UseCases } from "@/components/sections/use-cases";
 import { CTASection } from "@/components/sections/cta-section";
-import { ProductSchema } from "@/app/components/structured-data";
+import { ServiceSchema } from "@/app/components/structured-data";
 import { HowItWorks } from "@/components/sections/how-it-works";
 import {
   Dialog,
@@ -52,7 +52,7 @@ export default function Home() {
 
   return (
     <div className="flex flex-col">
-      <ProductSchema />
+      <ServiceSchema />
       {/* Hero Section */}
       <section className="relative min-h-[100dvh] md:h-[75vh] flex items-center justify-center overflow-hidden py-20 md:py-0">
         {/* Video Background Container */}


### PR DESCRIPTION
## What
GSC URL Inspection flagged the homepage **Product snippet** as *"1 invalid item detected"*. Root cause: the `Product` structured data has an `AggregateOffer` with a **missing required `lowPrice`** field.

Triya is a B2B, contact-for-pricing platform with no public price — and we previously (correctly) removed fabricated price/rating data. So there is no honest way to satisfy `Product`'s price requirement.

## Fix
- Convert the homepage `Product` schema → **`Service`** schema (`app/components/structured-data.tsx`). `Service` requires no price and is not subject to merchant-listing rich-result validation, so the invalid-item error clears truthfully.
- Preserve the four solution offerings (Smart City / Retail / Manufacturing / Events) via a price-less `OfferCatalog`.
- Rename the component `ProductSchema` → `ServiceSchema` and update its single usage in `app/page.tsx`.
- Expand `areaServed` to cover **Asia** in addition to Middle East & North Africa, on both the `Service` and `Organization` schemas.

## Verification
- `npm run build` compiles successfully (33/33 static pages).
- No fabricated data introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)