### PR TITLE
SEO: enrich retail use-case page with accurate capabilities

### DIFF
--- a/Triya_SEO_Keyword_Strategy.md
+++ b/Triya_SEO_Keyword_Strategy.md
@@ -1,0 +1,84 @@
+# Triya — SEO Keyword Strategy & Target Map
+
+**Goal:** Rank in Google's **top 5** for searches related to AI video analytics / CCTV intelligence — for a **global** buyer base. Win specific, differentiated, high-intent searches first (months); climb to global head terms as authority grows (long game).
+
+> Source of truth: Triya AI Capability Overview (cap_doc.pdf). Triya AI Limited — Abu Dhabi (ADGM-licensed). Live deployments/pilots in UAE & Southeast Asia; sells globally.
+
+---
+
+## What Triya actually is (positioning for all copy)
+**"Transform any camera into a privacy-first, AI-powered security & analytics solution."** Triya adds real-time AI to a customer's **existing CCTV** (RTSP/ONVIF, any IP camera) — **no camera replacement, no rip-and-replace.** Connect → Detect → Act. Available **cloud** (fastest start) or **on-premise/edge** (Triya Edge Box), same platform & AI library. Proof: 30-day pilot at a **Fortune 500 manufacturer**, 22 detection scenarios, on the customer's existing cameras.
+
+### Core differentiators (our moat — lead with these)
+- **Camera-agnostic / works with existing CCTV** — no rip-and-replace, no vendor lock-in.
+- **Natural-language video search** (English & Arabic) — "show me intrusions from yesterday." Rare among competitors.
+- **Cloud *and* on-premise/edge** deployment — privacy-first, data-sovereign option.
+- **Custom AI modules** — bespoke detection models delivered in weeks.
+
+---
+
+## Difficulty framing (global buyers → specificity & differentiation are our edge)
+- **Generic head terms** (`video analytics`, `AI video analytics`, `CCTV analytics`) → incumbent-owned (Avigilon/Motorola, Genetec/BriefCam, Verkada). **Top-5 = 18–30 mo**, needs authority. Build *toward* these.
+- **Differentiator terms** (`camera-agnostic`, `on-premise`, `edge`, `AI video search`) → our moat, **winnable 6–12 mo.** ← spearhead.
+- **Capability / scenario long-tail** (`fire and smoke detection AI`, `PPE compliance monitoring`, `ANPR software`) → high intent, **top-5 = 3–9 mo.** ← fastest wins.
+- **Competitor-alternative** (`BriefCam alternative`) → high intent, very winnable.
+
+The decisive lever for head terms = **authority** (deep content + backlinks + digital PR).
+
+---
+
+## Keyword clusters
+
+### 1. Head / category terms — *Tier 3 (long game)*
+video analytics · AI video analytics · CCTV analytics · CCTV video analytics · AI CCTV · video surveillance software · AI surveillance software · intelligent video analytics · video analytics software · computer vision surveillance
+
+### 2. Differentiator terms — *Tier 1–2, SPEARHEAD*
+camera-agnostic video analytics · add AI to existing CCTV · AI for existing cameras · upgrade CCTV to AI · works with any IP camera · ONVIF/RTSP AI analytics · on-premise video analytics · edge AI video analytics · cloud video analytics · privacy-first / data-sovereign video analytics · **AI video search · natural language CCTV search · search CCTV footage with AI** · no rip-and-replace surveillance
+
+### 3. Capability / scenario terms — *Tier 1 (fastest, high-intent) — straight from the product*
+- **Safety:** fire and smoke detection AI · AI smoke detection camera · PPE compliance monitoring · helmet / safety-helmet detection AI · smoking detection AI · fall detection AI ("person falling") · restricted-zone / line-crossing intrusion detection
+- **Security/perimeter:** intrusion detection AI · loitering detection · suspicious activity detection · face recognition access control · object-removal / theft detection · camera tampering detection
+- **Vehicles/access:** license plate recognition (ANPR/LPR) software · LPR gate access · parking violation / restriction detection
+- **Crowd/space:** people counting · occupancy analytics · crowd density / gathering detection · crowd statistics
+- **Workforce ops:** sleeping-on-duty detection · guard / people-on-duty monitoring · mobile-phone-use detection · uniform compliance detection · housekeeping verification · loading/unloading dwell-time
+- **Retail analytics:** store footfall analytics · customer heatmap / dwell-time · queue / wait-time monitoring · shelf / stock-out monitoring · loss prevention & shrinkage detection
+
+### 4. Vertical / industry terms — *Tier 1–2 — REAL verticals from cap doc (equal priority; Manufacturing & Industrial leads as most mature)*
+- **Manufacturing & Industrial:** manufacturing video analytics · factory safety AI · industrial video analytics · worker safety monitoring AI · production-line monitoring · plant safety camera AI
+- **Logistics & Distribution:** warehouse video analytics · logistics security AI · dock / yard management AI · loading-bay monitoring
+- **Retail & Consumer Spaces:** retail video analytics · retail loss prevention AI · store analytics · footfall & conversion analytics
+- **Real Estate & Facilities:** construction site safety AI · facility management video analytics · community / property security analytics · perimeter & access management · crowd safety at events & handovers
+- **Healthcare:** hospital video analytics · patient fall detection · healthcare facility security AI · clinical-area safety monitoring
+
+### 5. Commercial / comparison — *Tier 1–2, high intent*
+best video analytics software · AI video analytics providers / companies / vendors · enterprise video analytics solution · **[competitor] alternative** (BriefCam / Avigilon / Verkada / Calipsa / Eagle Eye) · video analytics pricing
+
+### 6. Informational / blog — *top-of-funnel, builds topical authority*
+what is AI video analytics · how to add AI to existing CCTV · edge vs cloud video analytics · how does AI CCTV work · AI surveillance ROI / cost · video analytics use cases by industry
+
+---
+
+## Priority tiers (global)
+
+**TIER 1 — 3–9 months (differentiator + scenario + competitor):**
+`camera-agnostic video analytics` · `add AI to existing CCTV` · `on-premise video analytics` · `edge AI video analytics` · `AI video search` · `fire and smoke detection AI` · `PPE compliance monitoring` · `license plate recognition software` · `fall detection AI` · `[competitor] alternative`
+
+**TIER 2 — 6–18 months (vertical heads + CCTV-AI cluster):**
+`manufacturing video analytics` · `warehouse video analytics` · `retail video analytics` · `industrial safety AI` · `intelligent video analytics` · `AI CCTV` · `CCTV video analytics` · `video analytics software`
+
+**TIER 3 — 18–30 months (global head terms, needs authority):**
+`video analytics` · `AI video analytics` · `CCTV analytics` · `video surveillance software`
+
+---
+
+## The work, mapped to pages
+1. **Spearhead differentiator pages (new):** *Camera-agnostic / Add AI to existing CCTV*, *On-premise & Edge video analytics*, *Cloud video analytics*, *AI video search (natural language)*. Globally winnable + exactly our moat.
+2. **Capability/scenario pages (new):** one strong page per high-intent scenario — *PPE compliance*, *Fire & smoke detection*, *ANPR/LPR*, *Fall detection*, *Intrusion / restricted-zone*, *People counting & crowd*, *Loss prevention*. Each = a magnet for a specific global search.
+3. **Re-align vertical pages to the REAL verticals:** keep & strengthen **Manufacturing/Industrial** and **Retail**; add **Logistics & Distribution**, **Real Estate & Facilities**, **Healthcare**. Decide what to do with the current **Smart Cities** and **Events** pages (not core verticals, but Smart Cities currently earns impressions — likely keep as supporting/SEO traffic, reframe under Real Estate & Facilities / public-safety).
+4. **Comparison content:** "[competitor] alternative" / "Triya vs X" pages.
+5. **Fix the blog:** 9 thin posts unindexed — improve depth + internal links; expand informational cluster for topical authority.
+6. **Authority building:** digital PR, backlinks, directories/marketplaces. The lever for Tier 3.
+7. **Measure** monthly in Search Console (wired up directly).
+
+---
+*Maintained by Claude as acting SEO lead. Global buyer base. Grounded in cap_doc.pdf. Updated as rankings move.*

--- a/app/use-cases/retail/page.tsx
+++ b/app/use-cases/retail/page.tsx
@@ -21,7 +21,14 @@ export default function RetailPage() {
         badge: "Retail",
         title: "Retail Video Analytics",
         titleHighlight: "for Loss Prevention & Growth",
-        subtitle: "Turn your store CCTV cameras into AI video analytics that prevent theft and shrinkage, deliver customer analytics, and optimize operations for modern retail."
+        subtitle: "Turn your existing store CCTV into AI video analytics — prevent theft and shrinkage, understand shoppers with footfall and heatmaps, and keep service fast. No camera replacement, no rip-and-replace."
+      },
+      intro: {
+        title: "Retail video analytics on the cameras you already own",
+        paragraphs: [
+          "Triya adds real-time artificial intelligence to your existing store CCTV, turning every camera into a retail video analytics and loss-prevention system. Because the platform is camera-agnostic and works over standard RTSP/ONVIF feeds, there is no rip-and-replace — your current cameras become an intelligent layer that protects stock and reveals how customers actually shop.",
+          "From footfall counting and dwell-time heatmaps to queue monitoring, shelf stock-out alerts and shrinkage detection, Triya watches every camera every second and alerts your team the moment something needs attention — across a single store or an entire chain, from one web portal, deployed in the cloud or fully on-premise."
+        ]
       },
       challenges: {
         title: "Retail Security & Operations Challenges",
@@ -49,40 +56,51 @@ export default function RetailPage() {
         ]
       },
       solution: {
-        title: "Triya.ai Retail Solution",
-        description: "Transform your store cameras into intelligent business tools that protect assets and drive revenue.",
+        title: "Retail Video Analytics Capabilities",
+        description: "Turn existing store cameras into a real-time analytics and operations layer: understand customers, protect stock, and keep service fast.",
         features: [
           {
-            title: "Real-time Theft Detection",
-            description: "Identify suspicious behavior and alert staff instantly to prevent losses",
-            stats: "70% loss reduction"
+            title: "Store Footfall Analytics",
+            description: "Customer footfall counts across every store entrance — by hour, day and location — to measure traffic and conversion.",
+            stats: "Per-entrance"
           },
           {
-            title: "Queue Management",
-            description: "Monitor checkout lines and alert staff when additional registers are needed",
-            stats: "40% faster checkout"
+            title: "Section Analytics & Heatmaps",
+            description: "Section-wise footfall, customer dwell-time analysis, and movement & engagement heatmaps to optimize layout and product placement.",
+            stats: "Heatmaps"
           },
           {
-            title: "Customer Analytics",
-            description: "Track foot traffic, dwell time, and shopping patterns to optimize layout",
-            stats: "25% sales increase"
+            title: "Queue & Service-Desk Monitoring",
+            description: "Billing and service-desk wait times, with automated alerts when queues exceed your defined thresholds.",
+            stats: "Real-time alerts"
           },
           {
-            title: "Heat Mapping",
-            description: "Visualize customer movement patterns to improve product placement",
-            stats: "Real-time insights"
+            title: "Shelf & Stock Monitoring",
+            description: "Shelf stock-occupancy levels with automated, image-attached alerts when stock falls below set limits.",
+            stats: "Auto alerts"
+          },
+          {
+            title: "Loss Prevention & Shrinkage",
+            description: "Object-movement, theft and suspicious-activity detection across the shop floor and stockroom to reduce shrinkage.",
+            stats: "Floor & stockroom"
+          },
+          {
+            title: "Staff Presence & Standards",
+            description: "Counter staffing, uniform compliance and housekeeping verification to keep service and standards consistent.",
+            stats: "Compliance"
           }
         ]
       },
       benefits: {
-        title: "Key Benefits",
+        title: "Why Retailers Choose Triya",
         items: [
-          "Reduce shrinkage by up to 70%",
-          "Improve customer satisfaction scores by 35%",
-          "Increase sales conversion by 25%",
-          "Optimize staff allocation in real-time",
-          "Complete GDPR/PDPL compliance",
-          "Arabic and English customer insights"
+          "Works with your existing CCTV — no camera replacement or rip-and-replace",
+          "Real-time theft, shrinkage and suspicious-activity alerts",
+          "Footfall, dwell-time and heatmap analytics to grow sales",
+          "Faster checkout with automated queue alerts",
+          "Shelf stock-out alerts to protect availability and revenue",
+          "Privacy-first: deploy in the cloud or fully on-premise",
+          "One dashboard for every store, with unlimited user access"
         ]
 },
       cta: {
@@ -155,6 +173,35 @@ export default function RetailPage() {
       </section>
 
 
+      {/* Intro Section */}
+      <section className="py-20">
+        <div className="container">
+          <motion.div
+            initial="hidden"
+            whileInView="visible"
+            viewport={{ once: true }}
+            variants={staggerChildren}
+            className="max-w-3xl mx-auto"
+          >
+            <motion.h2
+              className="text-3xl md:text-4xl font-bold mb-6"
+              variants={fadeInUp}
+            >
+              {t.intro.title}
+            </motion.h2>
+            {t.intro.paragraphs.map((para, index) => (
+              <motion.p
+                key={index}
+                className="text-lg text-muted-foreground mb-5"
+                variants={fadeInUp}
+              >
+                {para}
+              </motion.p>
+            ))}
+          </motion.div>
+        </div>
+      </section>
+
       {/* Challenges Section */}
       <section className="py-24">
         <div className="container">
@@ -164,7 +211,7 @@ export default function RetailPage() {
             viewport={{ once: true }}
             variants={staggerChildren}
           >
-            <motion.h2 
+            <motion.h2
               className="text-3xl md:text-4xl font-bold text-center mb-12"
               variants={fadeInUp}
             >


### PR DESCRIPTION
## What
The retail use-case page was thin (a few short cards) and used fabricated percentage stats — both reasons Google is reluctant to rank/index it. This rewrites it into substantive, accurate, keyword-targeted content.

## Changes
- **New intro prose section** — real indexable copy targeting "retail video analytics", "loss prevention AI", camera-agnostic / works-with-existing-CCTV.
- **6 real retail scenarios** from the capability doc (footfall, section analytics & heatmaps, queue/service-desk, shelf/stock-out, loss prevention & shrinkage, staff presence & standards) replacing the 4 generic cards.
- **Removed fabricated hard stats** ("70% loss reduction", "40% faster checkout", "25% sales increase", "improve satisfaction by 35%") → honest descriptors.
- Refreshed benefits to lead with the camera-agnostic + cloud/on-premise differentiators.
- Adds the SEO keyword strategy doc.

## Verification
- `npm run build` ✓ (33/33 static pages)
- No fabricated metrics introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)