### PR TITLE
SEO: enrich Manufacturing + add Real Estate & 'Add AI to CCTV' pages

### DIFF
--- a/app/solutions/add-ai-to-existing-cctv/layout.tsx
+++ b/app/solutions/add-ai-to-existing-cctv/layout.tsx
@@ -1,0 +1,26 @@
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Add AI to Your Existing CCTV | Camera-Agnostic Video Analytics — Triya',
+  description:
+    'Add AI to your existing CCTV with Triya. Camera-agnostic video analytics over RTSP/ONVIF works with any IP camera — upgrade CCTV to AI, no replacement, no lock-in.',
+  alternates: {
+    canonical: 'https://www.triya.ai/solutions/add-ai-to-existing-cctv/',
+  },
+  openGraph: {
+    title: 'Add AI to Your Existing CCTV | Camera-Agnostic Video Analytics — Triya',
+    description:
+      'Turn the cameras you already own into an AI video-analytics system. Camera-agnostic, RTSP/ONVIF, works with any IP camera — no rip-and-replace, no vendor lock-in.',
+    url: 'https://www.triya.ai/solutions/add-ai-to-existing-cctv/',
+    siteName: 'Triya',
+    type: 'website',
+  },
+};
+
+export default function AddAiToExistingCctvLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/app/solutions/add-ai-to-existing-cctv/page.tsx
+++ b/app/solutions/add-ai-to-existing-cctv/page.tsx
@@ -1,0 +1,381 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { fadeInUp, staggerChildren } from "@/lib/motion-variants";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
+import {
+  Camera,
+  PlugZap,
+  ScanEye,
+  BellRing,
+  ShieldAlert,
+  Flame,
+  HardHat,
+  PersonStanding,
+  Car,
+  Users,
+  EyeOff,
+  PackageSearch,
+  ArrowRight,
+  CheckCircle2,
+} from "lucide-react";
+
+export default function AddAiToExistingCctvPage() {
+  const content = {
+    hero: {
+      badge: "Camera-Agnostic Video Analytics",
+      title: "Add AI to the CCTV",
+      titleHighlight: "You Already Own",
+      subtitle:
+        "Triya turns your existing cameras into an AI video-analytics system. Camera-agnostic and built on standard RTSP/ONVIF, it works with any IP camera — no camera replacement, no rip-and-replace, no vendor lock-in.",
+    },
+    intro: {
+      title: "Camera-agnostic video analytics for the cameras you already own",
+      paragraphs: [
+        "Most teams already have CCTV — what they lack is intelligence on top of it. Triya adds AI to existing CCTV by connecting to your current cameras over standard RTSP/ONVIF, so any IP camera becomes a real-time AI sensor. There is no rip-and-replace and no proprietary hardware to buy: the cameras you already own become a camera-agnostic video-analytics platform that detects events, logs every alert, and lets your team search footage in plain language.",
+        "Because Triya is AI for existing cameras rather than a new camera line, you can upgrade CCTV to AI in days instead of quarters. Run it in the cloud for the fastest start with no on-site hardware, or fully on-premise on a Triya Edge Box where video never leaves your premises — the same platform either way. In a recent 30-day pilot, a Fortune 500 manufacturer ran 22 detection scenarios on its own existing cameras without swapping a single device.",
+      ],
+    },
+    how: {
+      title: "How it works: Connect, Detect, Act",
+      description:
+        "Three steps to turn existing CCTV into AI video analytics — no new cameras, no complex integration.",
+      steps: [
+        {
+          icon: PlugZap,
+          step: "01",
+          title: "Connect",
+          description:
+            "Your existing CCTV feeds connect to Triya over standard RTSP/ONVIF. Any IP camera works, so there is no camera replacement and no vendor lock-in.",
+        },
+        {
+          icon: ScanEye,
+          step: "02",
+          title: "Detect",
+          description:
+            "Triya's AI models analyze every feed in real time, logging each detection, hazard and alert so nothing is missed across your camera network.",
+        },
+        {
+          icon: BellRing,
+          step: "03",
+          title: "Act",
+          description:
+            "Your team accesses live views, detections and searchable insights through a secure web portal, with instant alerts via email, SMS or webhook.",
+        },
+      ],
+    },
+    detect: {
+      title: "What you can detect",
+      description:
+        "A library of AI detection scenarios runs on your existing IP cameras — combine the ones you need today and add more in weeks.",
+      features: [
+        {
+          icon: ShieldAlert,
+          title: "Intrusion & Restricted Zones",
+          description:
+            "Detect people entering restricted or off-limits areas and trigger instant alerts the moment a boundary is crossed.",
+          tag: "Security",
+        },
+        {
+          icon: Flame,
+          title: "Fire & Smoke Detection",
+          description:
+            "Spot early signs of fire and smoke across indoor and outdoor cameras to speed up response and reduce damage.",
+          tag: "Safety",
+        },
+        {
+          icon: HardHat,
+          title: "PPE & Helmet Compliance",
+          description:
+            "Verify that workers are wearing required helmets and protective equipment in designated zones.",
+          tag: "Compliance",
+        },
+        {
+          icon: PersonStanding,
+          title: "Fall Detection",
+          description:
+            "Identify slips and falls in real time so help can reach people faster on factory floors and public spaces.",
+          tag: "Safety",
+        },
+        {
+          icon: Car,
+          title: "License Plate Recognition (LPR)",
+          description:
+            "Read and log vehicle license plates at gates and entrances for access control and audit trails.",
+          tag: "Access",
+        },
+        {
+          icon: Users,
+          title: "People Counting & Crowd Density",
+          description:
+            "Count people and monitor crowd density to manage occupancy, queues and high-traffic areas.",
+          tag: "Operations",
+        },
+        {
+          icon: EyeOff,
+          title: "Loitering & Suspicious Activity",
+          description:
+            "Flag loitering and unusual behavior in sensitive areas before an incident escalates.",
+          tag: "Security",
+        },
+        {
+          icon: PackageSearch,
+          title: "Object & Theft Detection",
+          description:
+            "Detect object movement and removal to catch theft and shrinkage across the floor and storerooms.",
+          tag: "Loss prevention",
+        },
+      ],
+    },
+    benefits: {
+      title: "Why teams add AI to existing CCTV with Triya",
+      items: [
+        "Works with any IP camera over standard RTSP/ONVIF — no camera replacement",
+        "Camera-agnostic platform with no rip-and-replace and no vendor lock-in",
+        "Natural-language video search in English and Arabic — \"show me intrusions from yesterday\"",
+        "Privacy-first: deploy in the cloud or fully on-premise on a Triya Edge Box",
+        "Custom AI modules built in weeks to match your scenarios",
+        "Unlimited users, a mobile app, and instant alerts via email, SMS or webhook",
+      ],
+    },
+    cta: {
+      title: "Upgrade your existing CCTV to AI",
+      description:
+        "See camera-agnostic video analytics running on your own cameras. Book a demo and we'll show you how fast you can go live.",
+      primaryButton: "Book a Demo",
+    },
+  };
+
+  const t = content;
+
+  return (
+    <>
+      {/* Hero Section */}
+      <section className="relative min-h-[100dvh] md:h-[65vh] flex items-center justify-center overflow-hidden py-20 md:py-0">
+        {/* Video Background Container */}
+        <div className="absolute inset-0 z-0">
+          <video
+            autoPlay
+            muted
+            loop
+            playsInline
+            className="h-full w-full object-cover"
+            aria-label="AI video analytics running on existing CCTV cameras - Triya connects to any IP camera over RTSP and ONVIF to detect intrusions, fire, PPE compliance and more in real time"
+          >
+            <source src="/videos/hero_1.mp4" type="video/mp4" />
+          </video>
+          {/* Dark overlay for better text visibility */}
+          <div className="absolute inset-0 bg-black/50" />
+        </div>
+
+        <div className="container relative z-10">
+          <motion.div
+            initial="hidden"
+            animate="visible"
+            variants={staggerChildren}
+            className="max-w-4xl mx-auto text-center"
+          >
+            <motion.div variants={fadeInUp}>
+              <Badge variant="secondary" className="mb-4">
+                <Camera className="h-3 w-3 mr-1" />
+                {t.hero.badge}
+              </Badge>
+            </motion.div>
+            <motion.h1
+              className="text-4xl md:text-5xl lg:text-6xl font-bold mb-6 text-white"
+              variants={fadeInUp}
+            >
+              {t.hero.title}{" "}
+              <span className="bg-gradient-to-r from-yellow-400 to-orange-400 bg-clip-text text-transparent">
+                {t.hero.titleHighlight}
+              </span>
+            </motion.h1>
+            <motion.p className="text-xl text-gray-200 mb-8" variants={fadeInUp}>
+              {t.hero.subtitle}
+            </motion.p>
+            <motion.div
+              className="flex flex-col sm:flex-row gap-4 justify-center"
+              variants={fadeInUp}
+            >
+              <Button size="lg" className="gap-2 bg-primary hover:bg-primary/90" asChild>
+                <Link href="/contact/">
+                  {t.cta.primaryButton} <ArrowRight className="h-4 w-4" />
+                </Link>
+              </Button>
+            </motion.div>
+          </motion.div>
+        </div>
+      </section>
+
+      {/* Intro Section */}
+      <section className="py-20">
+        <div className="container">
+          <motion.div
+            initial="hidden"
+            whileInView="visible"
+            viewport={{ once: true }}
+            variants={staggerChildren}
+            className="max-w-3xl mx-auto"
+          >
+            <motion.h2 className="text-3xl md:text-4xl font-bold mb-6" variants={fadeInUp}>
+              {t.intro.title}
+            </motion.h2>
+            {t.intro.paragraphs.map((para, index) => (
+              <motion.p
+                key={index}
+                className="text-lg text-muted-foreground mb-5"
+                variants={fadeInUp}
+              >
+                {para}
+              </motion.p>
+            ))}
+          </motion.div>
+        </div>
+      </section>
+
+      {/* How it works Section */}
+      <section className="py-24 bg-muted/50">
+        <div className="container">
+          <motion.div
+            initial="hidden"
+            whileInView="visible"
+            viewport={{ once: true }}
+            variants={staggerChildren}
+            className="max-w-6xl mx-auto"
+          >
+            <motion.div className="text-center mb-12" variants={fadeInUp}>
+              <h2 className="text-3xl md:text-4xl font-bold mb-4">{t.how.title}</h2>
+              <p className="text-xl text-muted-foreground max-w-3xl mx-auto">
+                {t.how.description}
+              </p>
+            </motion.div>
+
+            <div className="grid gap-6 md:grid-cols-3">
+              {t.how.steps.map((step, index) => {
+                const Icon = step.icon;
+                return (
+                  <motion.div key={index} variants={fadeInUp}>
+                    <Card className="h-full">
+                      <CardContent className="pt-6">
+                        <div className="flex items-center gap-4 mb-4">
+                          <div className="h-12 w-12 rounded-lg bg-primary/10 flex items-center justify-center">
+                            <Icon className="h-6 w-6 text-primary" />
+                          </div>
+                          <span className="text-3xl font-bold text-muted-foreground/40">
+                            {step.step}
+                          </span>
+                        </div>
+                        <h3 className="text-xl font-semibold mb-2">{step.title}</h3>
+                        <p className="text-muted-foreground">{step.description}</p>
+                      </CardContent>
+                    </Card>
+                  </motion.div>
+                );
+              })}
+            </div>
+          </motion.div>
+        </div>
+      </section>
+
+      {/* What you can detect Section */}
+      <section className="py-24">
+        <div className="container">
+          <motion.div
+            initial="hidden"
+            whileInView="visible"
+            viewport={{ once: true }}
+            variants={staggerChildren}
+            className="max-w-6xl mx-auto"
+          >
+            <motion.div className="text-center mb-12" variants={fadeInUp}>
+              <h2 className="text-3xl md:text-4xl font-bold mb-4">{t.detect.title}</h2>
+              <p className="text-xl text-muted-foreground max-w-3xl mx-auto">
+                {t.detect.description}
+              </p>
+            </motion.div>
+
+            <div className="grid gap-8 md:grid-cols-2">
+              {t.detect.features.map((feature, index) => {
+                const Icon = feature.icon;
+                return (
+                  <motion.div key={index} variants={fadeInUp}>
+                    <Card className="h-full">
+                      <CardContent className="pt-6">
+                        <div className="flex items-start gap-4">
+                          <div className="h-12 w-12 rounded-lg bg-primary/10 flex items-center justify-center flex-shrink-0">
+                            <Icon className="h-6 w-6 text-primary" />
+                          </div>
+                          <div>
+                            <div className="flex items-center gap-3 mb-2">
+                              <h3 className="text-xl font-semibold">{feature.title}</h3>
+                              <Badge variant="outline">{feature.tag}</Badge>
+                            </div>
+                            <p className="text-muted-foreground">{feature.description}</p>
+                          </div>
+                        </div>
+                      </CardContent>
+                    </Card>
+                  </motion.div>
+                );
+              })}
+            </div>
+          </motion.div>
+        </div>
+      </section>
+
+      {/* Benefits Section */}
+      <section className="py-24 bg-muted/50">
+        <div className="container">
+          <motion.div
+            initial="hidden"
+            whileInView="visible"
+            viewport={{ once: true }}
+            variants={staggerChildren}
+            className="max-w-4xl mx-auto"
+          >
+            <motion.h2
+              className="text-3xl md:text-4xl font-bold text-center mb-12"
+              variants={fadeInUp}
+            >
+              {t.benefits.title}
+            </motion.h2>
+            <motion.div className="grid gap-4 md:grid-cols-2" variants={fadeInUp}>
+              {t.benefits.items.map((benefit, index) => (
+                <div key={index} className="flex items-start gap-3">
+                  <CheckCircle2 className="h-5 w-5 text-primary mt-1 flex-shrink-0" />
+                  <span className="text-lg">{benefit}</span>
+                </div>
+              ))}
+            </motion.div>
+          </motion.div>
+        </div>
+      </section>
+
+      {/* CTA Section */}
+      <section className="py-24 bg-primary/5">
+        <div className="container">
+          <motion.div
+            initial="hidden"
+            whileInView="visible"
+            viewport={{ once: true }}
+            variants={fadeInUp}
+            className="text-center max-w-3xl mx-auto"
+          >
+            <h2 className="text-3xl md:text-4xl font-bold mb-4">{t.cta.title}</h2>
+            <p className="text-xl text-muted-foreground mb-8">{t.cta.description}</p>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Button size="lg" className="gap-2 bg-primary hover:bg-primary/90" asChild>
+                <Link href="/contact/">
+                  {t.cta.primaryButton} <ArrowRight className="h-4 w-4" />
+                </Link>
+              </Button>
+            </div>
+          </motion.div>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/app/use-cases/real-estate/layout.tsx
+++ b/app/use-cases/real-estate/layout.tsx
@@ -1,0 +1,23 @@
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Real Estate & Facilities Video Analytics | AI CCTV for Property & Construction — Triya',
+  description: 'AI CCTV for facilities on your existing cameras: real estate and facilities management video analytics, construction site safety AI and LPR gate access.',
+  alternates: {
+    canonical: 'https://www.triya.ai/use-cases/real-estate/',
+  },
+  openGraph: {
+    title: 'Real Estate & Facilities Video Analytics | AI CCTV for Property & Construction — Triya',
+    description: 'Real estate and facilities management video analytics on your existing CCTV. Construction site safety AI, property security analytics, and license plate recognition gate access.',
+    url: 'https://www.triya.ai/use-cases/real-estate/',
+    type: 'website',
+  },
+};
+
+export default function RealEstateLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return children;
+}

--- a/app/use-cases/real-estate/page.tsx
+++ b/app/use-cases/real-estate/page.tsx
@@ -5,115 +5,109 @@ import { fadeInUp, staggerChildren } from "@/lib/motion-variants";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  Factory,
-  HardHat,
-  AlertTriangle,
-  Flame,
-  Activity,
-  ArrowRight,
-  CheckCircle2
-} from "lucide-react";
 import Link from "next/link";
-import { Breadcrumbs } from "@/components/shared/breadcrumbs";
+import {
+  Building2,
+  HardHat,
+  ShieldAlert,
+  Car,
+  ArrowRight,
+  CheckCircle2,
+  Clock
+} from "lucide-react";
 
-export default function ManufacturingPage() {
+export default function RealEstatePage() {
   const content = {
       hero: {
-        badge: "Manufacturing",
-        title: "Manufacturing & Industrial Video Analytics",
-        titleHighlight: "for Safer Factories",
-        subtitle: "Turn your existing factory CCTV into real-time, AI-powered worker safety monitoring — PPE compliance, fire and smoke detection, restricted-zone intrusion and fall detection. No camera replacement, no rip-and-replace, no vendor lock-in."
+        badge: "Real Estate & Facilities",
+        title: "Real Estate & Facilities Video Analytics",
+        titleHighlight: "for Property, Construction & Communities",
+        subtitle: "Turn your existing property and construction site CCTV into AI video analytics — enforce site safety, secure perimeters and assets, manage gate access with license plate recognition, and understand how facilities are used. No camera replacement, no rip-and-replace."
       },
       intro: {
-        title: "Industrial video analytics on the cameras you already own",
+        title: "Real estate and facilities video analytics on the cameras you already own",
         paragraphs: [
-          "Triya adds real-time artificial intelligence to your existing factory and plant CCTV, turning every camera into industrial video analytics for worker safety and operations. Because the platform is camera-agnostic and works over standard RTSP/ONVIF feeds, there is no rip-and-replace — your current IP cameras become an intelligent safety layer that watches every shop floor, loading bay and machine line, every second.",
-          "From PPE compliance monitoring and fire and smoke detection to restricted-zone intrusion near machinery and fall detection with instant alerts, Triya turns passive footage into factory safety AI that notifies your team the moment something needs attention — via email, SMS or webhook, from a single web portal, deployed in the cloud for the fastest start or fully on-premise on a Triya Edge Box so video never leaves your premises. Manufacturing is Triya's most mature vertical: a recent 30-day pilot at a Fortune 500 manufacturer covered 22 distinct AI detection scenarios using the customer's existing cameras."
+          "Triya adds real-time artificial intelligence to your existing CCTV across construction sites, communities and managed buildings, turning every camera into a property security analytics and facilities management video analytics system. Because the platform is camera-agnostic and works over standard RTSP/ONVIF feeds from any IP camera, there is no rip-and-replace and no vendor lock-in — your current cameras become an intelligent layer that protects people, assets and the public.",
+          "From construction site safety AI that flags missing helmets and PPE or intrusion into restricted zones, to perimeter and asset protection, license plate recognition gate access, and footfall in sales galleries and amenities, Triya watches every camera every second and alerts your team via email, SMS or webhook the moment something needs attention — across a single site or an entire portfolio, from one web portal, deployed in the cloud or fully on-premise."
         ]
       },
       challenges: {
-        title: "Manufacturing & Industrial Safety Challenges",
+        title: "Real Estate & Facilities Security Challenges",
         items: [
           {
             icon: HardHat,
-            title: "PPE Compliance",
-            description: "Manual monitoring of helmets, vests and safety gear across large facilities is inefficient and error-prone"
+            title: "Site Safety & Compliance",
+            description: "PPE and helmet non-compliance, restricted-zone intrusion and after-hours access go unnoticed on busy construction sites"
           },
           {
-            icon: AlertTriangle,
-            title: "Workplace Accidents",
-            description: "Falls and incidents near machinery need instant detection — delayed response can lead to serious injuries"
+            icon: ShieldAlert,
+            title: "Asset & Material Theft",
+            description: "Perimeter breaches and theft of materials from laydown and storage areas are costly and hard to catch in real time"
           },
           {
-            icon: Flame,
-            title: "Fire & Smoke Risk",
-            description: "Early fire and smoke ignition can go unnoticed by staff until it has spread across the floor"
+            icon: Car,
+            title: "Access & Parking Control",
+            description: "Manual gate access and parking enforcement across communities and basements is slow and inconsistent"
           },
           {
-            icon: Activity,
-            title: "Operational Blind Spots",
-            description: "Limited visibility into restricted-zone intrusion, dwell times and housekeeping standards"
+            icon: Clock,
+            title: "Incident Response",
+            description: "Delayed detection of crowds, dumping and intrusions means issues escalate before teams can act"
           }
         ]
       },
       solution: {
-        title: "Manufacturing Video Analytics Capabilities",
-        description: "Turn existing factory cameras into a real-time safety and operations layer: protect workers, catch hazards early, and keep standards consistent across every line.",
+        title: "Real Estate & Facilities Video Analytics Capabilities",
+        description: "Turn existing site and community cameras into a real-time AI CCTV for facilities — keep workers safe, protect assets, control access, and understand how spaces are used.",
         features: [
           {
-            title: "Fire & Smoke Detection",
-            description: "Detect early fire and smoke ignition across the shop floor, storage and loading areas, with instant alerts so teams can respond before it spreads.",
-            stats: "Instant alerts"
-          },
-          {
-            title: "PPE & Safety-Helmet Compliance",
-            description: "PPE compliance monitoring for safety helmets, vests and protective equipment, flagging workers operating without the required gear.",
-            stats: "Per-zone"
-          },
-          {
-            title: "Restricted-Zone Intrusion",
-            description: "Line-crossing and yellow-line intrusion detection near machinery and hazardous areas, alerting when workers enter restricted zones.",
+            title: "Construction Site Safety",
+            description: "Helmet and PPE compliance, restricted-zone intrusion around active works, after-hours site access detection and worker headcount on site.",
             stats: "Real-time"
           },
           {
-            title: "Fall Detection",
-            description: "Detect people falling down on the floor and trigger instant alerts so responders can reach an injured worker without delay.",
-            stats: "Instant alerts"
+            title: "Site & Asset Security",
+            description: "Perimeter and hoarding breach detection, plus material theft and object-movement monitoring across laydown and storage areas.",
+            stats: "Perimeter"
           },
           {
-            title: "On-Duty & Smoking Detection",
-            description: "Detect sleeping on duty, mobile-phone use, and smoking in prohibited areas to maintain safety and workplace standards.",
-            stats: "Per-shift"
+            title: "Community & Facility Operations",
+            description: "Visitor footfall in sales galleries and amenities, occupancy of shared spaces, cleaning and housekeeping verification, and illegal dumping detection.",
+            stats: "Occupancy"
           },
           {
-            title: "Uniform & Housekeeping Checks",
-            description: "Verify uniform compliance and housekeeping standards across the facility, with image-attached alerts when standards slip.",
-            stats: "Auto alerts"
+            title: "Vehicle & Access Management",
+            description: "License plate recognition gate access, contractor vehicle tracking, and parking enforcement across communities and basements.",
+            stats: "LPR gate access"
           },
           {
-            title: "Loading & Unloading Dwell-Time",
-            description: "Track loading and unloading dwell times at bays and docks to surface delays and improve throughput.",
-            stats: "Per-bay"
+            title: "Crowd Safety at Events & Handovers",
+            description: "Gathering detection, crowd density monitoring and people counting to keep events, launches and handovers safe.",
+            stats: "Crowd density"
+          },
+          {
+            title: "Any Camera, Cloud or Edge",
+            description: "Works over RTSP/ONVIF with any IP camera, with natural-language video search and custom AI modules delivered in weeks.",
+            stats: "No lock-in"
           }
         ]
       },
       benefits: {
-        title: "Why Manufacturers Choose Triya",
+        title: "Why Property & Facilities Teams Choose Triya",
         items: [
           "Works with your existing CCTV — no camera replacement or rip-and-replace",
-          "Real-time PPE, fire/smoke and restricted-zone alerts",
-          "Fall detection with instant alerts to speed up incident response",
-          "Alerts via email, SMS or webhook into the tools you already use",
-          "Privacy-first: deploy in the cloud or fully on-premise on a Triya Edge Box",
-          "Natural-language video search — \"show me intrusions from yesterday\"",
-          "One web portal for every site, with custom AI modules added in weeks"
+          "Real-time PPE, intrusion and after-hours access alerts for site safety",
+          "Perimeter breach, theft and object-movement detection for assets",
+          "License plate recognition for faster, automated gate access",
+          "Footfall and occupancy insights across galleries, amenities and shared spaces",
+          "Privacy-first: deploy in the cloud or fully on-premise at the edge",
+          "One dashboard for every site and community, with alerts via email, SMS or webhook"
         ]
       },
       cta: {
-        title: "Transform Your Manufacturing Security",
-        description: "See how Triya can enhance worker safety and productivity in your facility",
-        primaryButton: "Request Demo",
+        title: "Secure Your Sites, Communities & Facilities",
+        description: "Discover how AI CCTV for facilities can keep workers safe and protect your assets",
+        primaryButton: "Schedule Demo",
       }
   };
 
@@ -121,8 +115,6 @@ export default function ManufacturingPage() {
 
   return (
     <>
-      <Breadcrumbs />
-
       {/* Hero Section */}
       <section className="relative min-h-[100dvh] md:h-[65vh] flex items-center justify-center overflow-hidden py-20 md:py-0">
         {/* Video Background Container */}
@@ -133,9 +125,9 @@ export default function ManufacturingPage() {
             loop
             playsInline
             className="h-full w-full object-cover"
-            aria-label="Manufacturing AI surveillance - PPE detection, fire and smoke detection, fall detection and restricted-zone monitoring in industrial facilities"
+            aria-label="AI surveillance demonstration for real estate and facilities — smart cameras monitoring construction sites, communities and buildings for safety, perimeter security and access control"
           >
-            <source src="/videos/manufacturing_hero_1.mp4" type="video/mp4" />
+            <source src="/videos/hero_1.mp4" type="video/mp4" />
           </video>
           {/* Dark overlay for better text visibility */}
           <div className="absolute inset-0 bg-black/50" />
@@ -150,7 +142,7 @@ export default function ManufacturingPage() {
           >
             <motion.div variants={fadeInUp}>
               <Badge variant="secondary" className="mb-4">
-                <Factory className="h-3 w-3 mr-1" />
+                <Building2 className="h-3 w-3 mr-1" />
                 {t.hero.badge}
               </Badge>
             </motion.div>
@@ -180,6 +172,7 @@ export default function ManufacturingPage() {
           </motion.div>
         </div>
       </section>
+
 
       {/* Intro Section */}
       <section className="py-20">
@@ -211,7 +204,7 @@ export default function ManufacturingPage() {
       </section>
 
       {/* Challenges Section */}
-      <section className="py-24 bg-muted/50">
+      <section className="py-24">
         <div className="container">
           <motion.div
             initial="hidden"
@@ -250,7 +243,7 @@ export default function ManufacturingPage() {
       </section>
 
       {/* Solution Section */}
-      <section className="py-24">
+      <section className="py-24 bg-muted/50">
         <div className="container">
           <motion.div
             initial="hidden"
@@ -292,7 +285,7 @@ export default function ManufacturingPage() {
       </section>
 
       {/* Benefits Section */}
-      <section className="py-24 bg-muted/50">
+      <section className="py-24">
         <div className="container">
           <motion.div
             initial="hidden"
@@ -323,7 +316,7 @@ export default function ManufacturingPage() {
       </section>
 
       {/* CTA Section */}
-      <section className="py-24">
+      <section className="py-24 bg-primary/5">
         <div className="container">
           <motion.div
             initial="hidden"
@@ -335,10 +328,8 @@ export default function ManufacturingPage() {
             <h2 className="text-3xl md:text-4xl font-bold mb-4">{t.cta.title}</h2>
             <p className="text-xl text-muted-foreground mb-8">{t.cta.description}</p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <Button size="lg" className="gap-2" asChild>
-                <Link href="/contact/">
-                  {t.cta.primaryButton} <ArrowRight className="h-4 w-4" />
-                </Link>
+              <Button size="lg" className="gap-2">
+                {t.cta.primaryButton} <ArrowRight className="h-4 w-4" />
               </Button>
             </div>
           </motion.div>

--- a/components/shared/navbar/index.tsx
+++ b/components/shared/navbar/index.tsx
@@ -19,30 +19,43 @@ import { MobileNav } from "./mobile-nav";
 
 const content = {
   industries: "Industries",
+  solutions: "Solutions",
   blog: "Blog",
   faq: "FAQ",
   contact: "Contact",
   requestDemo: "Request Demo",
   industryItems: [
     {
-      title: "Manufacturing",
+      title: "Manufacturing & Industrial",
       href: "/use-cases/manufacturing/",
-      description: "PPE compliance and safety monitoring for industrial facilities",
+      description: "Factory safety AI: PPE compliance, fire & smoke, restricted-zone and fall detection",
     },
     {
       title: "Retail",
       href: "/use-cases/retail/",
-      description: "Theft prevention and customer analytics for stores",
+      description: "Retail video analytics: loss prevention, footfall, heatmaps and queue monitoring",
+    },
+    {
+      title: "Real Estate & Facilities",
+      href: "/use-cases/real-estate/",
+      description: "Construction safety, property security and LPR access for communities & facilities",
     },
     {
       title: "Smart Cities",
       href: "/use-cases/smart-cities/",
-      description: "Traffic management and public safety solutions",
+      description: "Traffic monitoring, crowd analytics and public-safety video analytics",
     },
     {
       title: "Event Management",
       href: "/use-cases/events/",
       description: "Crowd analytics and security for major events",
+    },
+  ],
+  solutionItems: [
+    {
+      title: "Add AI to Existing CCTV",
+      href: "/solutions/add-ai-to-existing-cctv/",
+      description: "Camera-agnostic video analytics — works with the cameras you already own",
     },
   ]
 };
@@ -119,6 +132,23 @@ export function Navbar() {
               </NavigationMenuContent>
             </NavigationMenuItem>
             
+            <NavigationMenuItem>
+              <NavigationMenuTrigger>{t.solutions}</NavigationMenuTrigger>
+              <NavigationMenuContent>
+                <ul className="grid w-[400px] gap-3 p-4 md:w-[500px]">
+                  {t.solutionItems.map((solution) => (
+                    <ListItem
+                      key={solution.title}
+                      title={solution.title}
+                      href={solution.href}
+                    >
+                      {solution.description}
+                    </ListItem>
+                  ))}
+                </ul>
+              </NavigationMenuContent>
+            </NavigationMenuItem>
+
             <NavigationMenuItem>
               <Link href="/blog/" legacyBehavior passHref>
                 <NavigationMenuLink className={navigationMenuTriggerStyle()}>

--- a/components/shared/navbar/mobile-nav.tsx
+++ b/components/shared/navbar/mobile-nav.tsx
@@ -16,10 +16,17 @@ const navItemsData = [
   {
     title: "Industries",
     items: [
-      { title: "Manufacturing", href: "/use-cases/manufacturing/" },
+      { title: "Manufacturing & Industrial", href: "/use-cases/manufacturing/" },
       { title: "Retail", href: "/use-cases/retail/" },
+      { title: "Real Estate & Facilities", href: "/use-cases/real-estate/" },
       { title: "Smart Cities", href: "/use-cases/smart-cities/" },
       { title: "Event Management", href: "/use-cases/events/" },
+    ],
+  },
+  {
+    title: "Solutions",
+    items: [
+      { title: "Add AI to Existing CCTV", href: "/solutions/add-ai-to-existing-cctv/" },
     ],
   },
   { title: "Blog", href: "/blog/" },


### PR DESCRIPTION
## What
Continues the keyword-strategy build. Three pages + navigation wiring, all grounded in the capability doc, zero fabricated metrics.

### New / changed pages
- **Manufacturing & Industrial** (enriched) — intro prose + 7 real safety scenarios (fire & smoke, PPE/helmet, restricted-zone, fall detection, on-duty/smoking, uniform/housekeeping, loading/unloading). Removed fabricated stats; added the real Fortune-500 / 22-scenario / 30-day pilot proof point.
- **Real Estate & Facilities** (new, `/use-cases/real-estate/`) — construction safety, site & asset security, community/facility ops, LPR gate access, crowd safety. Priority vertical #3.
- **Add AI to Existing CCTV** (new, `/solutions/add-ai-to-existing-cctv/`) — the spearhead differentiator page (camera-agnostic, works with existing cameras, Connect→Detect→Act, cloud or on-premise).

### Navigation
- New **Solutions** menu (desktop + mobile) → Add AI to Existing CCTV.
- **Real Estate & Facilities** added to the Industries menu; descriptions sharpened with target keywords.

## Verification
- `npm run build` ✓ 35/35 static pages.
- Scanned for fabricated percentage stats — none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)